### PR TITLE
fix(readme): installation step for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A few steps to start:
 
 - Require the plugin via composer (`composer require monsieurbiz/sylius-settings-plugin="@rc" --no-scripts`).
 - Edit the `config/bundles.php` (`MonsieurBiz\SyliusSettingsPlugin\MonsieurBizSyliusSettingsPlugin::class => ['all' => true],`).
-- Copy the config (`cp -Rv vendor/monsieurbiz/sylius-settings-plugin/recipes/1.0-dev/config/ config/`).
+- Copy the config (`cp -Rv vendor/monsieurbiz/sylius-settings-plugin/recipes/1.0-dev/config/ .`).
 - Run the diff in your migrations (`./bin/console doctrine:migration:diff`).
 - Execute the migrations (`./bin/console doctrine:migration:migrate`).
 - Continue to "[How it works](#how-it-works)".


### PR DESCRIPTION
Hi!

The current command `cp -Rv vendor/monsieurbiz/sylius-settings-plugin/recipes/1.0-dev/config/ config/` copy config files under `config/config/` folder, which is not wanted:

![2020-12-16_09-54](https://user-images.githubusercontent.com/2103975/102326529-cd728700-3f84-11eb-9ad4-f8e2c67b84e8.png)

Using `cp -Rv vendor/monsieurbiz/sylius-settings-plugin/recipes/1.0-dev/config/ .` works fine:
![image](https://user-images.githubusercontent.com/2103975/102326672-fabf3500-3f84-11eb-8ab1-2d0539861b0b.png)

Thanks