### PR TITLE
Allow Sylius 1.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.4]
+        mysql: [5.7]
 
     steps:
       - uses: actions/checkout@v2
@@ -67,6 +68,15 @@ jobs:
 #      - name: PHPunit
 #        run: ./vendor/bin/phpunit
 
+    services:
+
+      mysql:
+        image: percona:${{ matrix.mysql }}
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+
 
   sylius:
 
@@ -80,12 +90,12 @@ jobs:
       matrix:
         php: [7.4]
         sylius: [1.8, 1.9]
-        mariadb_version: [10.4.14]
+        mysql: [5.7]
 
     steps:
       - name: Setup some envs
         run: |
-          echo "DATABASE_URL=mysql://root@127.0.0.1/sylius?serverVersion=mariadb-${{ matrix.mariadb_version }}" >> $GITHUB_ENV
+          echo "DATABASE_URL=mysql://root@127.0.0.1/sylius" >> $GITHUB_ENV
 
       - name: Setup PHP
         run: |
@@ -185,8 +195,8 @@ jobs:
 
     services:
 
-      mariadb:
-        image: mariadb:${{ matrix.mariadb_version }}
+      mysql:
+        image: percona:${{ matrix.mysql }}
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.4]
-        sylius: [1.8]
+        sylius: [1.8, 1.9]
         mariadb_version: [10.4.14]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "~7.4",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "sylius/sylius": "~1.8.0"
+        "sylius/sylius": "~1.8.0 || ~1.9.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^6.1",

--- a/tests/Application/.env
+++ b/tests/Application/.env
@@ -15,7 +15,7 @@ APP_SECRET=EDITME
 # For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
 # If you use Symfony binary this URL is overridden by it
-DATABASE_URL=mysql://root@127.0.0.1/sylius?serverVersion=mariadb-10.4.14
+DATABASE_URL=mysql://root@127.0.0.1/sylius
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/tests/Application/docker-compose.yaml
+++ b/tests/Application/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
     database:
-        image: mariadb:10.4.14
+        image: percona:5.7
         ports:
             - 3306
         environment:


### PR DESCRIPTION
Use MYSQL on our plugin to avoid migrations diff due to Maria DB : https://github.com/Sylius/Sylius/pull/12413
Allow Sylius ^1.8