### PR TITLE
Use ShopperContextInterface instead of ShopperContext

### DIFF
--- a/src/Twig/Extension/SettingsExtension.php
+++ b/src/Twig/Extension/SettingsExtension.php
@@ -15,7 +15,7 @@ namespace MonsieurBiz\SyliusSettingsPlugin\Twig\Extension;
 
 use MonsieurBiz\SyliusSettingsPlugin\Settings\RegistryInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
-use Sylius\Component\Core\Context\ShopperContext;
+use Sylius\Component\Core\Context\ShopperContextInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\ExtensionInterface;
@@ -66,7 +66,7 @@ final class SettingsExtension extends AbstractExtension implements ExtensionInte
      */
     public function getSettingValue(array $context, string $alias, string $path)
     {
-        if (isset($context['sylius']) && $context['sylius'] instanceof ShopperContext) {
+        if (isset($context['sylius']) && $context['sylius'] instanceof ShopperContextInterface) {
             if ($settingsInstance = $this->settingsRegistry->getByAlias($alias)) {
                 return $settingsInstance->getCurrentValue(
                     $context['sylius']->getChannel(),


### PR DESCRIPTION
The `setting` TWIG function will always return null when the `sylius` global TWIG variable is not an instance of `\Sylius\Component\Core\Context\ShopperContext`, i.e. when a custom context is used. Instead, check if it implements `Sylius\Component\Core\Context\ShopperContextInterface`.
Always try to rely on abstractions in libraries.