### PR TITLE
Fixing the links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ The configuration is then required to run any console command.
 
 As a good start you can have a look at:
 
-- The [configuration file](https://github.com/monsieurbiz/SyliusSettingsPlugin/blob/master/tests/Application/config/packages/monsieurbiz_settings_plugin_custom.yaml) to add your own settings.
-- The [form with your own fields](https://github.com/monsieurbiz/SyliusSettingsPlugin/blob/master/tests/Application/src/Form/SettingsType.php).
+- The [configuration file](dist/config/packages/monsieurbiz_settings_plugin_custom.yaml) to add your own settings.
+- The [form with your own fields](dist/src/Form/SettingsType.php).
 
 Then you can get your settings using a twig function: `setting()`.  
-Have a look at [this example](https://github.com/monsieurbiz/SyliusSettingsPlugin/blob/master/tests/Application/templates/views/message.html.twig).
+Have a look at [this example](dist/templates/views/message.html.twig).
 
 You can also use the DI to get your Settings, as example with the settings in the test Application `app.default`:
 


### PR DESCRIPTION
The links were pointing to a file in the test directory which has been moved.

The links are now relative so that they point to the documentation relative to the repository and the branch.