### PR TITLE
add support to bypass prepending migrations

### DIFF
--- a/src/DependencyInjection/MonsieurBizSyliusSettingsExtension.php
+++ b/src/DependencyInjection/MonsieurBizSyliusSettingsExtension.php
@@ -46,6 +46,13 @@ final class MonsieurBizSyliusSettingsExtension extends Extension implements Prep
      */
     public function prepend(ContainerBuilder $container): void
     {
+        if (
+            $container->hasParameter('sylius_core.prepend_doctrine_migrations') &&
+            !$container->getParameter('sylius_core.prepend_doctrine_migrations')
+        ) {
+            return;
+        }
+
         $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
         $container->prependExtensionConfig('doctrine_migrations', [
             'migrations_paths' => array_merge(array_pop($doctrineConfig)['migrations_paths'] ?? [], [


### PR DESCRIPTION
add support to bypass prepending migrations by using the already implemented core feature sylius_core.prepend_doctrine_migrations