### PR TITLE
Be able to extends settings form

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ It's also possible to run test fixtures with a local suite in development: `make
 By default, a fixture will replace the value of a setting if it already exists. 
 If you want to keep a value as it is in the database when running this fixture, you can use the flag `ignore_if_exists: true` for each element that you want to be kept.
 
+### Extends existing settings form
+
+If you want to add a field to an existing settings form (like in another plugin), you can check [the example in the test app](dist/src/Form/SettingsExtensionType.php)
+
 ### Use CLI
 
 You can use a CLI command to set a value for a setting directly from the console:

--- a/dist/config/packages/monsieurbiz_settings_plugin_custom.yaml
+++ b/dist/config/packages/monsieurbiz_settings_plugin_custom.yaml
@@ -11,6 +11,7 @@ monsieurbiz_sylius_settings:
                 form: App\Form\SettingsType
             default_values:
                 demo_message: My amazing message
+                demo_title: My amazing title
                 enabled: true
 
 sylius_ui:

--- a/dist/src/Form/SettingsExtensionType.php
+++ b/dist/src/Form/SettingsExtensionType.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class SettingsExtensionType extends AbstractSettingsExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($this->isDefaultForm($builder)) {
+            $this->addWithDefaultCheckbox(
+                $builder,
+                'demo_title',
+                TextType::class,
+                [
+                    'required' => true,
+                    'constraints' => [
+                        new Assert\NotBlank(),
+                    ],
+                ]
+            );
+        } else {
+            $this->addWithDefaultCheckbox(
+                $builder,
+                'demo_title',
+                TextType::class,
+                [
+                    'required' => false,
+                ]
+            );
+        }
+    }
+
+    public static function getExtendedTypes(): array
+    {
+        return [
+            SettingsType::class,
+        ];
+    }
+}

--- a/dist/templates/views/message.html.twig
+++ b/dist/templates/views/message.html.twig
@@ -1,5 +1,6 @@
 <p>
 {% if setting('app.default', 'enabled') %}
+    {{ setting('app.default', 'demo_title') }}
     {{ setting('app.default', 'demo_message') }}
 {% else %}
     {{ 'Message is disabled'|trans }}

--- a/src/Form/AbstractSettingsExtension.php
+++ b/src/Form/AbstractSettingsExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Form;
+
+use MonsieurBiz\SyliusSettingsPlugin\Settings\Settings;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+abstract class AbstractSettingsExtension extends AbstractTypeExtension implements SettingsExtensionInterface
+{
+    public function addWithDefaultCheckbox(FormBuilderInterface $builder, string $child, string $type = null, array $options = []): self
+    {
+        $data = (array) $builder->getData();
+        $builder->add($child, $type, $options);
+        if (!$this->isDefaultForm($builder)) {
+            $builder->add($child . '___' . Settings::DEFAULT_KEY, DefaultCheckboxType::class, [
+                'label' => 'monsieurbiz.settings.ui.use_default_value',
+                'related_form_child' => $builder->get($child),
+                'data' => !\array_key_exists($child, $data),
+                'required' => true,
+            ]);
+        }
+
+        return $this;
+    }
+
+    protected function isDefaultForm(FormBuilderInterface $builder): bool
+    {
+        return !$builder->getOption('show_default_checkboxes', true);
+    }
+}

--- a/src/Form/SettingsExtensionInterface.php
+++ b/src/Form/SettingsExtensionInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Form;
+
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeExtensionInterface;
+
+interface SettingsExtensionInterface extends FormTypeExtensionInterface
+{
+    /**
+     * This method should add a checkbox field to the form when adding a new setting's field.
+     *
+     * @return $this
+     */
+    public function addWithDefaultCheckbox(FormBuilderInterface $builder, string $child, string $type = null, array $options = []): self;
+}


### PR DESCRIPTION
- Add classes to be able to extends a setting form type
- Add an example of settings form extension in test app
- Update README with link to extends a settings form type

Example in test app : 

![image psd](https://github.com/monsieurbiz/SyliusSettingsPlugin/assets/11380627/8310ec60-c98a-4718-a131-c42943a58589)
