### PR TITLE
Allow permission RBAC for sylius plus on routes

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -46,18 +46,24 @@ jobs:
 
       - run: mkdir -p /home/runner/{.composer/cache,.config/composer}
 
-      - uses: actions/cache@v3
-        id: cache-composer
-        with:
-          path: /home/runner/.composer/cache
-          key: composer2-php:${{ matrix.php }}-sylius:${{ matrix.sylius }}-${{ github.sha }}
-          restore-keys: composer2-php:${{ matrix.php }}-sylius:${{ matrix.sylius }}-
+      -   name: Determine composer cache directory
+          id: composer-cache-directory
+          working-directory: plugin
+          run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
-      - name: Composer
-        run: sudo composer self-update
+      -   name: Cache dependencies installed with composer
+          uses: actions/cache@v3
+          id: cache-composer
+          with:
+              path: ${{ steps.composer-cache-directory.outputs.directory }}
+              key: composer2-php:${{ matrix.php }}-sylius:${{ matrix.sylius }}-${{ hashFiles('**/composer.json') }}
+              restore-keys: composer2-php:${{ matrix.php }}-sylius:${{ matrix.sylius }}-
 
-      - name: Composer Github Auth
-        run: composer config -g github-oauth.github.com ${{ github.token }}
+      -   name: Ensure that composer cache directory exists
+          run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
+
+      -   name: Composer Github Auth
+          run: composer config -g github-oauth.github.com ${{ github.token }}
 
       - name: Create Sylius-Standard project without install
         run: |

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -30,23 +30,23 @@ jobs:
         run: |
           echo ${{ matrix.php }} > .php-version
 
-      - uses: actions/cache@v3
-        id: cache-composer
-        with:
-          path: /home/runner/.composer/cache
-          key: composer2-php:${{ matrix.php }}-${{ github.sha }}
-          restore-keys: composer2-php:${{ matrix.php }}-
+      -   name: Determine composer cache directory
+          id: composer-cache-directory
+          run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
-      - run: mkdir -p /home/runner/{.composer/cache,.config/composer}
-        if: steps.cache-composer.outputs.cache-hit != 'true'
+      -   name: Cache dependencies installed with composer
+          uses: actions/cache@v3
+          id: cache-composer
+          with:
+              path: ${{ steps.composer-cache-directory.outputs.directory }}
+              key: composer2-php:${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
+              restore-keys: composer2-php:${{ matrix.php }}-
 
-      - name: Composer
-        run: sudo composer self-update
+      -   name: Ensure that composer cache directory exists
+          run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
-      - name: Composer Github Auth
-        run: composer config -g github-oauth.github.com ${{ github.token }}
-
-      - uses: actions/checkout@v2
+      -   name: Composer Github Auth
+          run: composer config -g github-oauth.github.com ${{ github.token }}
 
       - name: Install PHP dependencies
         run: composer update --prefer-dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,36 +30,34 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          ini-values: date.timezone=UTC
+      -   name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+              php-version: ${{ matrix.php }}
+              ini-values: date.timezone=UTC
+              tools: symfony-cli
 
-      - name: Set project php-version
-        run: |
-          echo ${{ matrix.php }} > .php-version
+      -   name: Set project php-version
+          run: |
+              echo ${{ matrix.php }} > .php-version
 
-      - name: Install symfony CLI
-        run: |
-          curl https://get.symfony.com/cli/installer | bash
-          echo "${HOME}/.symfony5/bin" >> $GITHUB_PATH
+      -   name: Determine composer cache directory
+          id: composer-cache-directory
+          run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
-        id: cache-composer
-        with:
-          path: /home/runner/.composer/cache
-          key: composer2-php:${{ matrix.php }}-${{ github.sha }}
-          restore-keys: composer2-php:${{ matrix.php }}-
+      -   name: Cache dependencies installed with composer
+          uses: actions/cache@v3
+          id: cache-composer
+          with:
+              path: ${{ steps.composer-cache-directory.outputs.directory }}
+              key: composer2-php:${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
+              restore-keys: composer2-php:${{ matrix.php }}-
 
-      - run: mkdir -p /home/runner/{.composer/cache,.config/composer}
-        if: steps.cache-composer.outputs.cache-hit != 'true'
+      -   name: Ensure that composer cache directory exists
+          run: mkdir -p ${{ steps.composer-cache-directory.outputs.directory }}
 
-      - name: Composer
-        run: sudo composer self-update
-
-      - name: Composer Github Auth
-        run: composer config -g github-oauth.github.com ${{ github.token }}
+      -   name: Composer Github Auth
+          run: composer config -g github-oauth.github.com ${{ github.token }}
 
       - run: make install
 

--- a/Makefile
+++ b/Makefile
@@ -214,19 +214,6 @@ endif
 ${APP_DIR}/.env.local:
 	touch ${APP_DIR}/.env.local
 
-
-###
-### GITHUB CODESPACES
-### ¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯
-
-codespace.hostname: ${APP_DIR}/.env.local ## Init the SYLIUS_FIXTURES_HOSTNAME variable in .env.local
-ifdef CODESPACES
-	echo SYLIUS_FIXTURES_HOSTNAME=${CODESPACE_NAME}-8000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN} >> ${APP_DIR}/.env.local
-endif
-
-${APP_DIR}/.env.local:
-	touch ${APP_DIR}/.env.local
-
 ###
 ### HELP
 ### ¯¯¯¯

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-mbstring": "*",
         "ext-json": "*",
         "sylius/sylius": ">=1.10 <1.13",
-        "symfony/cache": "^5.4.28 || ^6.0"
+        "symfony/cache": "^5.4.28 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "symfony/flex": "@stable",
         "symfony/web-profiler-bundle": "@stable",
         "phpmd/phpmd": "@stable",
-        "friendsofphp/php-cs-fixer": "@stable"
+        "friendsofphp/php-cs-fixer": "@stable",
+        "symfony/twig-bridge": "^5.4"
     },
     "prefer-stable": true,
     "autoload": {

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -2,13 +2,29 @@ monsieurbiz_sylius_settings_admin_index:
     path: settings
     controller: MonsieurBiz\SyliusSettingsPlugin\Controller\SettingsController::indexAction
     methods: ['GET']
+    defaults:
+        _sylius:
+            alias: monsieurbiz.settings_admin_index
+            section: admin
+            permission: true
+        
 
 monsieurbiz_sylius_settings_admin_edit:
     path: settings/edit/{alias}
     controller: MonsieurBiz\SyliusSettingsPlugin\Controller\SettingsController::formAction
     methods: ['GET']
+    defaults:
+        _sylius:
+            alias: monsieurbiz.settings_admin_edit
+            section: admin
+            permission: true
 
 monsieurbiz_sylius_settings_admin_edit_post:
     path: settings/edit/{alias}
     controller: MonsieurBiz\SyliusSettingsPlugin\Controller\SettingsController::formAction
     methods: ['PUT']
+    defaults:
+        _sylius:
+            alias: monsieurbiz.settings_admin_edit_post
+            section: admin
+            permission: true

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -18,3 +18,13 @@ monsieurbiz:
                 title:
                     sylius_default_values: Sylius' default values
                     channel_default_values: Default values for %channelName%
+sylius_plus:
+    rbac:
+        parent:
+            monsieurbiz:
+                settings_admin_edit_posts: 'Save settings'
+                settings_admin_edits: 'Edit settings'
+                settings_admin_indices: 'Settings list'
+        monsieurbiz_sylius_settings_admin_edit_post: 'Save'
+        monsieurbiz_sylius_settings_admin_edit: 'Update'
+        monsieurbiz_sylius_settings_admin_index: 'Index' 

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -18,3 +18,13 @@ monsieurbiz:
                 title:
                     sylius_default_values: Valeurs par défaut de Sylius
                     channel_default_values: Valeurs par défaut de %channelName%
+sylius_plus:
+    rbac:
+        parent:
+            monsieurbiz:
+                settings_admin_edit_posts: 'Sauvegarde réglages' 
+                settings_admin_edits: 'Éditer réglages'
+                settings_admin_indices: 'Lister réglages'
+        monsieurbiz_sylius_settings_admin_edit_post: 'Sauvegarde'
+        monsieurbiz_sylius_settings_admin_edit: 'Update'
+        monsieurbiz_sylius_settings_admin_index: 'Index' 


### PR DESCRIPTION
Add permission on routes so the RBAC of Sylius Plus can put be used for the routes of the plugin.

For Sylius Standard it's changing nothing.