### PR TITLE
Admin: Add an overlay to disable complex fields

### DIFF
--- a/src/Resources/public/css/settings.css
+++ b/src/Resources/public/css/settings.css
@@ -1,0 +1,14 @@
+.disabled-input {
+    position:relative;
+}
+
+.disabled-input:after {
+    content:'';
+    position:absolute;
+    top:0;
+    left:0;
+    width:100%;
+    height:100%;
+    background-color:rgba(255,255,255,0.6);
+    z-index:100;
+}

--- a/src/Resources/public/js/default.js
+++ b/src/Resources/public/js/default.js
@@ -1,89 +1,142 @@
-// function to disable the related input field
-function disableRelatedInput(relatedInput) {
-  relatedInput.disabled = 'disabled';
-  relatedInput.parentNode.classList.add('disabled-input');
+const DefaultFieldManager = {
+  // Constants for custom events
+  EVENTS: {
+    FIELD_DISABLED: 'mbiz:config:disabled-field',
+    FIELD_ENABLED: 'mbiz:config:enabled-field'
+  },
 
-  // if input has "data-file-type" attribute, get parent "monsieurbiz-sylius-file-manager__field" element, find last "field" element and add disabled class
-  if (relatedInput.dataset.fileType) {
-    const buttonContainer = relatedInput.closest('.monsieurbiz-sylius-file-manager__field').lastElementChild;
+  // Constants for CSS selectors
+  SELECTORS: {
+    COMPONENTS: '[data-component]',
+    FILE_MANAGER_FIELD: '.monsieurbiz-sylius-file-manager__field',
+    DEFAULT_COMPONENT: 'mbiz-default'
+  },
+
+  // Constants for CSS classes
+  CLASSES: {
+    DISABLED_INPUT: 'disabled-input',
+    FIELD: 'field',
+    GRID: 'ui grid',
+    TWELVE_WIDE: 'field twelve wide column',
+    FOUR_WIDE: 'field four wide column'
+  },
+
+  FOCUS_DELAY: 100,
+
+  /**
+   * @param {HTMLElement} relatedInput
+   */
+  disableRelatedInput(relatedInput) {
+    relatedInput.disabled = true;
+    relatedInput.parentNode.classList.add(this.CLASSES.DISABLED_INPUT);
+
+    this.handleFileTypeField(relatedInput, true);
+    this.dispatchFieldEvent(this.EVENTS.FIELD_DISABLED, relatedInput);
+  },
+
+  /**
+   * @param {HTMLElement} relatedInput
+   */
+  enableRelatedInput(relatedInput) {
+    relatedInput.disabled = false;
+    relatedInput.parentNode.classList.remove(this.CLASSES.DISABLED_INPUT);
+
+    this.handleFileTypeField(relatedInput, false);
+    this.dispatchFieldEvent(this.EVENTS.FIELD_ENABLED, relatedInput);
+
+    setTimeout(() => relatedInput.focus(), this.FOCUS_DELAY);
+  },
+
+  /**
+   * Custom treatment for file type fields because the form type adds buttons to manage files
+   *
+   * @param {HTMLElement} relatedInput
+   * @param {boolean} isDisabled
+   */
+  handleFileTypeField(relatedInput, isDisabled) {
+    if (!relatedInput.dataset.fileType) return;
+
+    const buttonContainer = relatedInput.closest(this.SELECTORS.FILE_MANAGER_FIELD)?.lastElementChild;
     if (buttonContainer) {
-      buttonContainer.classList.add('disabled-input');
-    }
-  }
-
-  // dispatch custom disabled event to custom scripts
-  document.dispatchEvent(new CustomEvent('mbiz:config:disabled-field', {
-    detail: {
-      relatedInput: relatedInput
-    }
-  }));
-}
-
-// function to enable the related input field
-function enableRelatedInput(relatedInput) {
-  relatedInput.disabled = '';
-  relatedInput.parentNode.classList.remove('disabled-input');
-  if (relatedInput.dataset.fileType) {
-    const buttonContainer = relatedInput.closest('.monsieurbiz-sylius-file-manager__field').lastElementChild;
-    if (buttonContainer) {
-      buttonContainer.classList.remove('disabled-input');
-    }
-  }
-
-  // dispatch custom enabled event to custom scripts
-  document.dispatchEvent(new CustomEvent('mbiz:config:enabled-field', {
-    detail: {
-      relatedInput: relatedInput
-    }
-  }));
-
-  window.setTimeout(function () {
-    relatedInput.focus();
-  }, 100);
-}
-
-(function () {
-  document.addEventListener("DOMContentLoaded", function() {
-    const components = document.querySelectorAll('[data-component]');
-    for (const component of components) {
-      switch (component.dataset.component) {
-        case 'mbiz-default':
-          (function (component) {
-            const relatedId = component.dataset.relatedId;
-            const relatedInput = document.getElementById(relatedId);
-
-            // Reorganize the two fields
-            if (component.dataset.reorganize) {
-              var valueField = relatedInput.closest('.field');
-              var defaultField = component.closest('.field');
-              var fieldsContainer = document.createElement('div');
-              var grid = document.createElement('div');
-
-              valueField.parentNode.insertBefore(fieldsContainer, valueField);
-              fieldsContainer.appendChild(grid);
-              grid.appendChild(valueField);
-              grid.appendChild(defaultField);
-
-              fieldsContainer.className = 'field';
-              grid.className = 'ui grid';
-              valueField.className = 'field twelve wide column';
-              defaultField.className = 'field four wide column';
-            }
-
-            if (component.checked) {
-              disableRelatedInput(relatedInput);
-            }
-            component.addEventListener('change', function (e) {
-              if (!e.target.checked) {
-                enableRelatedInput(relatedInput);
-              } else {
-                disableRelatedInput(relatedInput);
-              }
-            });
-          })(component);
-          break;
-        default:
+      if (isDisabled) {
+        buttonContainer.classList.add(this.CLASSES.DISABLED_INPUT);
+      } else {
+        buttonContainer.classList.remove(this.CLASSES.DISABLED_INPUT);
       }
-    };
-  });
-})();
+    }
+  },
+
+  /**
+   * @param {string} eventName
+   * @param {HTMLElement} relatedInput
+   */
+  dispatchFieldEvent(eventName, relatedInput) {
+    document.dispatchEvent(new CustomEvent(eventName, {
+      detail: { relatedInput }
+    }));
+  },
+
+  /**
+   * @param {HTMLElement} component
+   * @param {HTMLElement} relatedInput
+   */
+  reorganizeFields(component, relatedInput) {
+    if (!component.dataset.reorganize) {
+      return;
+    }
+
+    const valueField = relatedInput.closest(`.${this.CLASSES.FIELD}`);
+    const defaultField = component.closest(`.${this.CLASSES.FIELD}`);
+
+    const fieldsContainer = document.createElement('div');
+    const grid = document.createElement('div');
+
+    valueField.parentNode.insertBefore(fieldsContainer, valueField);
+    fieldsContainer.appendChild(grid);
+    grid.appendChild(valueField);
+    grid.appendChild(defaultField);
+
+    fieldsContainer.className = this.CLASSES.FIELD;
+    grid.className = this.CLASSES.GRID;
+    valueField.className = this.CLASSES.TWELVE_WIDE;
+    defaultField.className = this.CLASSES.FOUR_WIDE;
+  },
+
+  /**
+   * @param {HTMLElement} component
+   */
+  initDefaultComponent(component) {
+    const relatedId = component.dataset.relatedId;
+    const relatedInput = document.getElementById(relatedId);
+    if (!relatedInput) {
+      return;
+    }
+
+    this.reorganizeFields(component, relatedInput);
+
+    if (component.checked) {
+      this.disableRelatedInput(relatedInput);
+    }
+    component.addEventListener('change', (e) => {
+      if (e.target.checked) {
+        this.disableRelatedInput(relatedInput);
+      } else {
+        this.enableRelatedInput(relatedInput);
+      }
+    });
+  },
+
+  init() {
+    document.addEventListener('DOMContentLoaded', () => {
+      const components = document.querySelectorAll(this.SELECTORS.COMPONENTS);
+
+      components.forEach(component => {
+        if (component.dataset.component === this.SELECTORS.DEFAULT_COMPONENT) {
+          this.initDefaultComponent(component);
+        }
+      });
+    });
+  }
+};
+
+DefaultFieldManager.init();

--- a/src/Resources/public/js/default.js
+++ b/src/Resources/public/js/default.js
@@ -1,3 +1,47 @@
+// function to disable the related input field
+function disableRelatedInput(relatedInput) {
+  relatedInput.disabled = 'disabled';
+  relatedInput.parentNode.classList.add('disabled-input');
+
+  // if input has "data-file-type" attribute, get parent "monsieurbiz-sylius-file-manager__field" element, find last "field" element and add disabled class
+  if (relatedInput.dataset.fileType) {
+    const buttonContainer = relatedInput.closest('.monsieurbiz-sylius-file-manager__field').lastElementChild;
+    if (buttonContainer) {
+      buttonContainer.classList.add('disabled-input');
+    }
+  }
+
+  // dispatch custom disabled event to custom scripts
+  document.dispatchEvent(new CustomEvent('mbiz:config:disabled-field', {
+    detail: {
+      relatedInput: relatedInput
+    }
+  }));
+}
+
+// function to enable the related input field
+function enableRelatedInput(relatedInput) {
+  relatedInput.disabled = '';
+  relatedInput.parentNode.classList.remove('disabled-input');
+  if (relatedInput.dataset.fileType) {
+    const buttonContainer = relatedInput.closest('.monsieurbiz-sylius-file-manager__field').lastElementChild;
+    if (buttonContainer) {
+      buttonContainer.classList.remove('disabled-input');
+    }
+  }
+
+  // dispatch custom enabled event to custom scripts
+  document.dispatchEvent(new CustomEvent('mbiz:config:enabled-field', {
+    detail: {
+      relatedInput: relatedInput
+    }
+  }));
+
+  window.setTimeout(function () {
+    relatedInput.focus();
+  }, 100);
+}
+
 (function () {
   document.addEventListener("DOMContentLoaded", function() {
     const components = document.querySelectorAll('[data-component]');
@@ -7,19 +51,6 @@
           (function (component) {
             const relatedId = component.dataset.relatedId;
             const relatedInput = document.getElementById(relatedId);
-            if (component.checked) {
-              relatedInput.disabled = 'disabled';
-            }
-            component.addEventListener('change', function (e) {
-              if (!e.target.checked) {
-                relatedInput.disabled = '';
-                window.setTimeout(function () {
-                  relatedInput.focus();
-                }, 100);
-              } else {
-                relatedInput.disabled = 'disabled';
-              }
-            });
 
             // Reorganize the two fields
             if (component.dataset.reorganize) {
@@ -38,6 +69,17 @@
               valueField.className = 'field twelve wide column';
               defaultField.className = 'field four wide column';
             }
+
+            if (component.checked) {
+              disableRelatedInput(relatedInput);
+            }
+            component.addEventListener('change', function (e) {
+              if (!e.target.checked) {
+                enableRelatedInput(relatedInput);
+              } else {
+                disableRelatedInput(relatedInput);
+              }
+            });
           })(component);
           break;
         default:

--- a/src/Resources/views/Crud/edit.html.twig
+++ b/src/Resources/views/Crud/edit.html.twig
@@ -6,6 +6,11 @@
 
 {% form_theme form '@MonsieurBizSyliusSettingsPlugin/Form/theme.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('bundles/monsieurbizsyliussettingsplugin/css/settings.css') }}">
+{% endblock %}
+
 {% block content %}
 
     <div class="ui stackable two column grid">


### PR DESCRIPTION
 Such as the wysiwyg editor, rich editor, media manager field, etc.

https://github.com/user-attachments/assets/e815a08d-84ed-439c-a276-78f4b8589eba

With the test app, you can't see the benefit, but with plugins like RichEditor and MediaManage, it's very useful because the WYSIWYG editor is enabled for example.

Example with the new script:
![image](https://github.com/user-attachments/assets/a0e02d3a-1f1c-4ace-aef4-c80a718be8fb)
![image](https://github.com/user-attachments/assets/98c48d0d-2632-4489-b292-31d215c12bbc)

For Monsieur Team, ask me a demo with a complex setting if you want ;)
