### PR TITLE
fix(menu): use Sylius 2.x extras.routes format

### DIFF
--- a/src/Entity/Setting/Setting.php
+++ b/src/Entity/Setting/Setting.php
@@ -162,13 +162,13 @@ class Setting implements SettingInterface
     private function getTypeFromValue($value): string
     {
         $types = [
-            'double' => function (): string {
+            'double' => static function (): string {
                 return SettingInterface::STORAGE_TYPE_FLOAT;
             },
-            'array' => function (): string {
+            'array' => static function (): string {
                 return SettingInterface::STORAGE_TYPE_JSON;
             },
-            'object' => function (object $value): string {
+            'object' => static function (object $value): string {
                 if ($value instanceof DateTimeInterface) {
                     return SettingInterface::STORAGE_TYPE_DATETIME;
                 }
@@ -178,16 +178,16 @@ class Setting implements SettingInterface
 
                 throw new LogicException('Impossible to match the type of the value.');
             },
-            'string' => function (): string {
+            'string' => static function (): string {
                 return SettingInterface::STORAGE_TYPE_TEXT;
             },
-            'boolean' => function (): string {
+            'boolean' => static function (): string {
                 return SettingInterface::STORAGE_TYPE_BOOLEAN;
             },
-            'integer' => function (): string {
+            'integer' => static function (): string {
                 return SettingInterface::STORAGE_TYPE_INTEGER;
             },
-            'NULL' => function (): string {
+            'NULL' => static function (): string {
                 return SettingInterface::STORAGE_TYPE_TEXT;
             },
         ];

--- a/src/Fixture/SettingsFixture.php
+++ b/src/Fixture/SettingsFixture.php
@@ -34,7 +34,6 @@ final class SettingsFixture extends AbstractResourceFixture
 
     protected function configureResourceNode(ArrayNodeDefinition $resourceNode): void
     {
-        /** @phpstan-ignore-next-line */
         $resourceNode
             ->children()
                 ->scalarNode('alias')->cannotBeEmpty()->end()

--- a/src/Form/AbstractSettingsExtension.php
+++ b/src/Form/AbstractSettingsExtension.php
@@ -16,9 +16,13 @@ namespace MonsieurBiz\SyliusSettingsPlugin\Form;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\Settings;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 abstract class AbstractSettingsExtension extends AbstractTypeExtension implements SettingsExtensionInterface
 {
+    /**
+     * @param class-string<FormTypeInterface>|null $type
+     */
     public function addWithDefaultCheckbox(FormBuilderInterface $builder, string $child, string $type = null, array $options = []): self
     {
         $data = (array) $builder->getData();

--- a/src/Form/AbstractSettingsType.php
+++ b/src/Form/AbstractSettingsType.php
@@ -16,6 +16,7 @@ namespace MonsieurBiz\SyliusSettingsPlugin\Form;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\Settings;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractSettingsType extends AbstractType implements SettingsTypeInterface
@@ -35,6 +36,9 @@ abstract class AbstractSettingsType extends AbstractType implements SettingsType
         ]);
     }
 
+    /**
+     * @param class-string<FormTypeInterface>|null $type
+     */
     public function addWithDefaultCheckbox(FormBuilderInterface $builder, string $child, string $type = null, array $options = []): self
     {
         $data = (array) $builder->getData();

--- a/src/Menu/AdminMenuListener.php
+++ b/src/Menu/AdminMenuListener.php
@@ -33,7 +33,7 @@ final class AdminMenuListener
             if (null !== ($configurationMenu = $menu->getChild('configuration'))) {
                 $settings = $configurationMenu
                     ->addChild('monsieurbiz_settings', ['route' => 'monsieurbiz_sylius_settings_admin_index', 'extras' => ['routes' => [
-                        'monsieurbiz_sylius_settings_admin_edit',
+                        ['route' => 'monsieurbiz_sylius_settings_admin_edit'],
                     ]]])
                     ->setLabel('monsieurbiz.settings.menu.admin.configuration.settings')
                     ->setLabelAttribute('icon', 'cog')

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -18,6 +18,7 @@ use MonsieurBiz\SyliusSettingsPlugin\Exception\SettingsException;
 use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsType;
 use MonsieurBiz\SyliusSettingsPlugin\Repository\SettingRepositoryInterface;
 use Sylius\Component\Channel\Model\ChannelInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
@@ -77,6 +78,8 @@ final class Settings implements SettingsInterface
 
     /**
      * @throws SettingsException
+     *
+     * @return class-string<FormTypeInterface>
      */
     public function getFormClass(): string
     {
@@ -86,6 +89,7 @@ final class Settings implements SettingsInterface
             throw new SettingsException(\sprintf('Class %s should extend %s', $className, AbstractSettingsType::class));
         }
 
+        /** @var class-string<FormTypeInterface> $className */
         return $className;
     }
 

--- a/src/Settings/SettingsInterface.php
+++ b/src/Settings/SettingsInterface.php
@@ -16,6 +16,7 @@ namespace MonsieurBiz\SyliusSettingsPlugin\Settings;
 use MonsieurBiz\SyliusSettingsPlugin\Exception\SettingsException;
 use MonsieurBiz\SyliusSettingsPlugin\Repository\SettingRepositoryInterface;
 use Sylius\Component\Channel\Model\ChannelInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 interface SettingsInterface
@@ -42,6 +43,8 @@ interface SettingsInterface
 
     /**
      * @throws SettingsException
+     *
+     * @return class-string<FormTypeInterface>
      */
     public function getFormClass(): string;
 


### PR DESCRIPTION
## Problem

The `extras.routes` entries added in [6da0969][2] (shipped in v2.0.3) use the Sylius 1.x legacy string format:

```php
'extras' => ['routes' => [
    'monsieurbiz_sylius_settings_admin_edit',
]]
```

Throughout the Sylius core admin menu, `extras.routes` entries are declared as associative arrays with a `route` key, see [`MainMenuBuilder.php`][1]. Any menu listener that follows this convention (reading `$route['route']`) fails with `Cannot access offset of type string on string` on the items built by this plugin (in my case, with `acseo/acl-plugin`).

## Fix

Use the 2.x format:

```php
['route' => 'monsieurbiz_sylius_settings_admin_edit'],
```

This preserves the original intent of [6da0969][2] (keep the Settings menu active when editing a setting)  `extras.routes` is only consumed by external menu listeners, not by the plugin itself.

[1]: https://github.com/Sylius/Sylius/blob/v2.2.5/src/Sylius/Bundle/AdminBundle/Menu/MainMenuBuilder.php#L72-L90
[2]: https://github.com/monsieurbiz/SyliusSettingsPlugin/commit/6da09697980990aa3155a4f3f4175a7e952f7a06
