### PR TITLE
Improve admin settings discovery with search and categories

### DIFF
--- a/dist/config/packages/dev/monsieurbiz_settings_plugin_fake.yaml
+++ b/dist/config/packages/dev/monsieurbiz_settings_plugin_fake.yaml
@@ -1,0 +1,141 @@
+monsieurbiz_sylius_settings:
+    plugins:
+        app.fake_blog:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Blog Settings
+            category: Content
+            description: Lorem ipsum dolor sit amet, blog configuration for testing search results.
+            icon: tabler:article
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Lorem ipsum blog demo message
+                demo_title: Blog lorem fixture
+                enabled: true
+        app.fake_checkout:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Checkout Settings
+            category: Sales
+            description: Consectetur adipiscing elit checkout options for testing many settings.
+            icon: tabler:shopping-cart
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Checkout lorem ipsum confirmation text
+                demo_title: Checkout demo fixture
+                enabled: true
+        app.fake_catalog:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Catalog Settings
+            category: Content
+            description: Sed do eiusmod tempor catalog parameters with searchable lorem content.
+            icon: tabler:category
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Catalog demo lorem merchandising message
+                demo_title: Catalog fake setting
+                enabled: false
+        app.fake_marketing:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Marketing Settings
+            category: Marketing
+            description: Incididunt ut labore marketing configuration used to test card filtering.
+            icon: tabler:speakerphone
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Marketing lorem demo banner
+                demo_title: Campaign fake fixture
+                enabled: true
+        app.fake_shipping:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Shipping Settings
+            category: Content
+            description: Et dolore magna aliqua shipping preferences with ipsum search content.
+            icon: tabler:truck-delivery
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Shipping lorem ipsum tracking message
+                demo_title: Delivery demo fixture
+                enabled: true
+        app.fake_payment:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Payment Settings
+            category: Sales
+            description: Ut enim ad minim veniam payment options generated for local testing.
+            icon: tabler:credit-card
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Payment demo lorem notification
+                demo_title: Payment fake setting
+                enabled: false
+        app.fake_reviews:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Reviews Settings
+            category: Content
+            description: Quis nostrud exercitation review settings with dummy searchable text.
+            icon: tabler:stars
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Reviews lorem demo moderation message
+                demo_title: Reviews fixture title
+                enabled: true
+        app.fake_loyalty:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Loyalty Settings
+            category: Marketing
+            description: Ullamco laboris loyalty configuration for search and display testing.
+            icon: tabler:gift
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Loyalty ipsum demo points message
+                demo_title: Loyalty fake fixture
+                enabled: true
+        app.fake_seo:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake SEO Settings
+            description: Nisi ut aliquip SEO metadata settings full of lorem fixture values.
+            icon: tabler:world-search
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: SEO lorem demo meta description
+                demo_title: Search engine fake setting
+                enabled: false
+        app.fake_analytics:
+            vendor_name: Fake Fixtures
+            vendor_url:
+            plugin_name: Fake Analytics Settings
+            category: Content
+            description: Ex ea commodo consequat analytics configuration for local-only tests.
+            icon: tabler:chart-bar
+            use_locales: true
+            classes:
+                form: App\Form\SettingsType
+            default_values:
+                demo_message: Analytics lorem ipsum dashboard message
+                demo_title: Analytics demo fixture
+                enabled: true

--- a/dist/config/packages/dev/monsieurbiz_settings_plugin_fake.yaml
+++ b/dist/config/packages/dev/monsieurbiz_settings_plugin_fake.yaml
@@ -9,11 +9,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:article
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Lorem ipsum blog demo message
-                demo_title: Blog lorem fixture
-                enabled: true
+                blog_headline: Lorem ipsum blog headline
         app.fake_checkout:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -23,11 +21,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:shopping-cart
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Checkout lorem ipsum confirmation text
-                demo_title: Checkout demo fixture
-                enabled: true
+                checkout_notice: Checkout lorem ipsum confirmation text
         app.fake_catalog:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -37,11 +33,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:category
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Catalog demo lorem merchandising message
-                demo_title: Catalog fake setting
-                enabled: false
+                catalog_page_size: 24
         app.fake_marketing:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -51,11 +45,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:speakerphone
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Marketing lorem demo banner
-                demo_title: Campaign fake fixture
-                enabled: true
+                marketing_sender_email: newsletter@example.com
         app.fake_shipping:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -65,11 +57,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:truck-delivery
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Shipping lorem ipsum tracking message
-                demo_title: Delivery demo fixture
-                enabled: true
+                shipping_tracking_url: https://carrier.example/track/{number}
         app.fake_payment:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -79,11 +69,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:credit-card
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Payment demo lorem notification
-                demo_title: Payment fake setting
-                enabled: false
+                payment_retry_limit: 3
         app.fake_reviews:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -93,11 +81,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:stars
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Reviews lorem demo moderation message
-                demo_title: Reviews fixture title
-                enabled: true
+                reviews_moderation_note: Reviews lorem demo moderation note
         app.fake_loyalty:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -107,11 +93,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:gift
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Loyalty ipsum demo points message
-                demo_title: Loyalty fake fixture
-                enabled: true
+                loyalty_points_ratio: 2_per_euro
         app.fake_seo:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -120,11 +104,9 @@ monsieurbiz_sylius_settings:
             icon: tabler:world-search
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: SEO lorem demo meta description
-                demo_title: Search engine fake setting
-                enabled: false
+                seo_meta_description: SEO lorem demo meta description
         app.fake_analytics:
             vendor_name: Fake Fixtures
             vendor_url:
@@ -134,8 +116,6 @@ monsieurbiz_sylius_settings:
             icon: tabler:chart-bar
             use_locales: true
             classes:
-                form: App\Form\SettingsType
+                form: App\Form\FakeSettingsType
             default_values:
-                demo_message: Analytics lorem ipsum dashboard message
-                demo_title: Analytics demo fixture
-                enabled: true
+                analytics_tracking_id: G-LOREMIPSUM

--- a/dist/src/Form/FakeSettingsType.php
+++ b/dist/src/Form/FakeSettingsType.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsType;
+use MonsieurBiz\SyliusSettingsPlugin\Form\SettingsTypeInterface;
+use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class FakeSettingsType extends AbstractSettingsType implements SettingsTypeInterface
+{
+    /**
+     * @var array<string, array{field: string, type: class-string, options: array<string, mixed>}>
+     */
+    private const FIELDS_BY_ALIAS = [
+        'app.fake_blog' => [
+            'field' => 'blog_headline',
+            'type' => TextType::class,
+            'options' => [
+                'label' => 'Blog headline',
+                'attr' => ['placeholder' => 'Enter the blog landing headline'],
+                'help' => 'Shown above the latest blog articles.',
+            ],
+        ],
+        'app.fake_checkout' => [
+            'field' => 'checkout_notice',
+            'type' => TextareaType::class,
+            'options' => [
+                'label' => 'Checkout notice',
+                'attr' => ['placeholder' => 'Write a short checkout notice'],
+                'help' => 'Displayed before customers confirm their cart.',
+            ],
+        ],
+        'app.fake_catalog' => [
+            'field' => 'catalog_page_size',
+            'type' => IntegerType::class,
+            'options' => [
+                'label' => 'Catalog page size',
+                'attr' => ['placeholder' => 'Products per catalog page'],
+                'help' => 'Controls how many products appear in listings.',
+            ],
+        ],
+        'app.fake_marketing' => [
+            'field' => 'marketing_sender_email',
+            'type' => EmailType::class,
+            'options' => [
+                'label' => 'Marketing sender email',
+                'attr' => ['placeholder' => 'newsletter@example.com'],
+                'help' => 'Used as the sender address for campaigns.',
+            ],
+        ],
+        'app.fake_shipping' => [
+            'field' => 'shipping_tracking_url',
+            'type' => UrlType::class,
+            'options' => [
+                'label' => 'Shipping tracking URL',
+                'attr' => ['placeholder' => 'https://carrier.example/track/{number}'],
+                'help' => 'Template used to link shipment tracking numbers.',
+            ],
+        ],
+        'app.fake_payment' => [
+            'field' => 'payment_retry_limit',
+            'type' => IntegerType::class,
+            'options' => [
+                'label' => 'Payment retry limit',
+                'attr' => ['placeholder' => 'Maximum payment retries'],
+                'help' => 'Limits how many times a failed payment is retried.',
+            ],
+        ],
+        'app.fake_reviews' => [
+            'field' => 'reviews_moderation_note',
+            'type' => TextareaType::class,
+            'options' => [
+                'label' => 'Reviews moderation note',
+                'attr' => ['placeholder' => 'Explain the review moderation rule'],
+                'help' => 'Internal note for the review moderation team.',
+            ],
+        ],
+        'app.fake_loyalty' => [
+            'field' => 'loyalty_points_ratio',
+            'type' => ChoiceType::class,
+            'options' => [
+                'label' => 'Loyalty points ratio',
+                'placeholder' => 'Choose a loyalty earning ratio',
+                'help' => 'Defines how quickly customers earn reward points.',
+                'choices' => [
+                    'One point per euro' => '1_per_euro',
+                    'Two points per euro' => '2_per_euro',
+                    'Five points per euro' => '5_per_euro',
+                ],
+            ],
+        ],
+        'app.fake_seo' => [
+            'field' => 'seo_meta_description',
+            'type' => TextareaType::class,
+            'options' => [
+                'label' => 'SEO meta description',
+                'attr' => ['placeholder' => 'Describe the storefront for search engines'],
+                'help' => 'Fallback description used by search result snippets.',
+            ],
+        ],
+        'app.fake_analytics' => [
+            'field' => 'analytics_tracking_id',
+            'type' => TextType::class,
+            'options' => [
+                'label' => 'Analytics tracking ID',
+                'attr' => ['placeholder' => 'G-XXXXXXXXXX'],
+                'help' => 'Identifier used by the analytics integration.',
+            ],
+        ],
+    ];
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $settings = $options['settings'];
+        if (!$settings instanceof SettingsInterface) {
+            return;
+        }
+
+        $fieldConfig = self::FIELDS_BY_ALIAS[$settings->getAlias()] ?? null;
+        if (null === $fieldConfig) {
+            return;
+        }
+
+        $this->addWithDefaultCheckbox(
+            $builder,
+            $fieldConfig['field'],
+            $fieldConfig['type'],
+            $fieldConfig['options'] + [
+                'required' => false,
+            ],
+        );
+    }
+}

--- a/src/Command/ClearSettingsSearchCacheCommand.php
+++ b/src/Command/ClearSettingsSearchCacheCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Command;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'monsieurbiz:settings:search-cache:clear', description: 'Clears the settings search cache pool.')]
+final class ClearSettingsSearchCacheCommand extends Command
+{
+    public function __construct(
+        private CacheItemPoolInterface $settingsSearchCache,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $symfonyStyle = new SymfonyStyle($input, $output);
+
+        if (!$this->settingsSearchCache->clear()) {
+            $symfonyStyle->error('Unable to clear the settings search cache.');
+
+            return Command::FAILURE;
+        }
+
+        $symfonyStyle->success('Settings search cache cleared.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -17,6 +17,7 @@ use MonsieurBiz\SyliusSettingsPlugin\CacheWarmer\SettingsCacheWarmerInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Factory\Form\MainSettingsFormTypeFactoryInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Form\MainSettingsType;
 use MonsieurBiz\SyliusSettingsPlugin\Processor\SettingsProcessorInterface;
+use MonsieurBiz\SyliusSettingsPlugin\Search\SettingsSearchIndexBuilder;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\RegistryInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -32,13 +33,17 @@ final class SettingsController extends AbstractController
         private MainSettingsFormTypeFactoryInterface $formFactory,
         private TagAwareCacheInterface $monsieurbizSettingsCache,
         private SettingsCacheWarmerInterface $cacheWarmer,
+        private SettingsSearchIndexBuilder $settingsSearchIndexBuilder,
     ) {
     }
 
     public function indexAction(RegistryInterface $registry): Response
     {
+        $settings = $registry->getAllSettings();
+
         return $this->render('@MonsieurBizSyliusSettingsPlugin/admin/settings/index.html.twig', [
-            'settings' => $registry->getAllSettings(),
+            'settings' => $settings,
+            'settings_search_index' => $this->settingsSearchIndexBuilder->build($settings),
         ]);
     }
 

--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -18,6 +18,7 @@ use MonsieurBiz\SyliusSettingsPlugin\Factory\Form\MainSettingsFormTypeFactoryInt
 use MonsieurBiz\SyliusSettingsPlugin\Form\MainSettingsType;
 use MonsieurBiz\SyliusSettingsPlugin\Processor\SettingsProcessorInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Search\SettingsSearchIndexBuilder;
+use MonsieurBiz\SyliusSettingsPlugin\Settings\CategorizedSettingsInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\RegistryInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -43,8 +44,25 @@ final class SettingsController extends AbstractController
 
         return $this->render('@MonsieurBizSyliusSettingsPlugin/admin/settings/index.html.twig', [
             'settings' => $settings,
+            'settings_categories' => $this->getSettingsCategories($settings),
             'settings_search_index' => $this->settingsSearchIndexBuilder->build($settings),
         ]);
+    }
+
+    /**
+     * @param array<SettingsInterface> $settingsCollection
+     *
+     * @return array<string, string|null>
+     */
+    private function getSettingsCategories(array $settingsCollection): array
+    {
+        $categories = [];
+
+        foreach ($settingsCollection as $settings) {
+            $categories[$settings->getAlias()] = $settings instanceof CategorizedSettingsInterface ? $settings->getCategory() : null;
+        }
+
+        return $categories;
     }
 
     public function formAction(Request $request, RegistryInterface $registry, string $alias): Response

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ final class Configuration implements ConfigurationInterface
                             ->scalarNode('vendor_name')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('vendor_url')->defaultNull()->end()
                             ->scalarNode('plugin_name')->isRequired()->cannotBeEmpty()->end()
+                            ->scalarNode('category')->defaultNull()->end()
                             ->scalarNode('description')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('icon')->isRequired()->cannotBeEmpty()->end()
                             ->booleanNode('use_locales')->end()

--- a/src/DependencyInjection/MonsieurBizSyliusSettingsExtension.php
+++ b/src/DependencyInjection/MonsieurBizSyliusSettingsExtension.php
@@ -46,6 +46,8 @@ final class MonsieurBizSyliusSettingsExtension extends Extension implements Prep
      */
     public function prepend(ContainerBuilder $container): void
     {
+        $this->addCachePools($container);
+
         if (
             $container->hasParameter('sylius_core.prepend_doctrine_migrations')
             && !$container->getParameter('sylius_core.prepend_doctrine_migrations')
@@ -59,11 +61,9 @@ final class MonsieurBizSyliusSettingsExtension extends Extension implements Prep
                 'MonsieurBiz\SyliusSettingsPlugin\Migrations' => '@MonsieurBizSyliusSettingsPlugin/Migrations',
             ]),
         ]);
-
-        $this->addCachePool($container);
     }
 
-    private function addCachePool(ContainerBuilder $container): void
+    private function addCachePools(ContainerBuilder $container): void
     {
         $settingConfigs = $container->getExtensionConfig($this->getAlias());
         $configuration = $this->getConfiguration([], $container);
@@ -83,6 +83,10 @@ final class MonsieurBizSyliusSettingsExtension extends Extension implements Prep
                         'adapter' => $cacheAdapter,
                         'public' => false,
                         'tags' => true,
+                    ],
+                    'monsieurbiz_settings.search_cache' => [
+                        'adapter' => $cacheAdapter,
+                        'public' => false,
                     ],
                 ],
             ],

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -43,6 +43,14 @@ services:
         arguments: 
             $className: 'MonsieurBiz\SyliusSettingsPlugin\Entity\Setting\Setting'
 
+    MonsieurBiz\SyliusSettingsPlugin\Search\SettingsSearchIndexBuilder:
+        arguments:
+            $settingsSearchCache: '@monsieurbiz_settings.search_cache'
+
+    MonsieurBiz\SyliusSettingsPlugin\Command\ClearSettingsSearchCacheCommand:
+        arguments:
+            $settingsSearchCache: '@monsieurbiz_settings.search_cache'
+
     # Live components
     sylius_admin.monsieurbiz_settings.twig.component.settings.main_form:
         class: MonsieurBiz\SyliusSettingsPlugin\Twig\Components\SettingFormComponent

--- a/src/Resources/config/sylius/twig_hooks/settings/index.yaml
+++ b/src/Resources/config/sylius/twig_hooks/settings/index.yaml
@@ -13,6 +13,9 @@ sylius_twig_hooks:
                 configuration:
                     title: monsieurbiz.settings.ui.settings.title
                 priority: 100
+            search:
+                template: '@MonsieurBizSyliusSettingsPlugin/admin/settings/index/content/header/title_block/search.html.twig'
+                priority: 0
             actions:
                 enabled: false
 

--- a/src/Resources/public/css/settings.css
+++ b/src/Resources/public/css/settings.css
@@ -12,3 +12,18 @@
     background-color:rgba(255,255,255,0.6);
     z-index:100;
 }
+
+[data-mbiz-settings-list] .mbiz-settings-card {
+    transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+[data-mbiz-settings-list] .mbiz-settings-card:hover,
+[data-mbiz-settings-list] .mbiz-settings-card:focus-within {
+    background-color: rgba(var(--tblr-primary-rgb, var(--bs-primary-rgb)), 0.03);
+    border-color: rgba(var(--tblr-primary-rgb, var(--bs-primary-rgb)), 0.35);
+    box-shadow: 0 0.125rem 0.5rem rgba(var(--tblr-primary-rgb, var(--bs-primary-rgb)), 0.12);
+}
+
+[data-mbiz-settings-list] .mbiz-settings-card .stretched-link:focus-visible {
+    outline: 0;
+}

--- a/src/Resources/public/css/settings.css
+++ b/src/Resources/public/css/settings.css
@@ -14,7 +14,21 @@
 }
 
 [data-mbiz-settings-list] .mbiz-settings-card {
+    position: relative;
     transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+[data-mbiz-settings-list] .mbiz-settings-card__field-match-indicator {
+    position: absolute;
+    top: var(--tblr-spacer-2, 0.5rem);
+    right: var(--tblr-spacer-2, 0.5rem);
+    z-index: 2;
+    width: 0.625rem;
+    height: 0.625rem;
+    border-radius: 50%;
+    background-color: var(--tblr-primary, var(--bs-primary));
+    box-shadow: 0 0 0 0.1875rem rgba(var(--tblr-primary-rgb, var(--bs-primary-rgb)), 0.16);
+    pointer-events: none;
 }
 
 [data-mbiz-settings-list] .mbiz-settings-card:hover,

--- a/src/Resources/public/js/default.js
+++ b/src/Resources/public/js/default.js
@@ -110,6 +110,7 @@ const SettingsCardSearch = {
     CARD: '[data-mbiz-settings-card]',
     GROUP: '[data-mbiz-settings-group]',
     EMPTY: '[data-mbiz-settings-search-empty]',
+    FIELD_MATCH_INDICATOR: '[data-mbiz-settings-field-match-indicator]',
   },
 
   CLASSES: {
@@ -123,15 +124,45 @@ const SettingsCardSearch = {
       .replace(/[\u0300-\u036f]/g, '');
   },
 
+  getCardMatches(card, query) {
+    if (!query) {
+      return {
+        metadata: false,
+        fields: false,
+      };
+    }
+
+    const metadataText = this.normalize(card.dataset.searchMetadata || '');
+    const fieldsText = this.normalize(card.dataset.searchFields || '');
+    const fallbackText = this.normalize(card.dataset.searchText || '');
+
+    return {
+      metadata: metadataText ? metadataText.includes(query) : fallbackText.includes(query),
+      fields: fieldsText ? fieldsText.includes(query) : false,
+    };
+  },
+
+  toggleFieldMatchIndicator(card, isVisible) {
+    const indicator = card.querySelector(this.SELECTORS.FIELD_MATCH_INDICATOR);
+
+    if (!indicator) {
+      return;
+    }
+
+    indicator.classList.toggle(this.CLASSES.HIDDEN, !isVisible);
+    indicator.setAttribute('aria-hidden', String(!isVisible));
+  },
+
   filterCards(input, cards, groups, emptyMessage) {
     const query = this.normalize(input.value.trim());
     let visibleCardsCount = 0;
 
     cards.forEach((card) => {
-      const searchText = this.normalize(card.dataset.searchText || '');
-      const isVisible = !query || searchText.includes(query);
+      const matches = this.getCardMatches(card, query);
+      const isVisible = !query || matches.metadata || matches.fields;
 
       card.classList.toggle(this.CLASSES.HIDDEN, !isVisible);
+      this.toggleFieldMatchIndicator(card, Boolean(query && matches.fields));
 
       if (isVisible) {
         visibleCardsCount += 1;

--- a/src/Resources/public/js/default.js
+++ b/src/Resources/public/js/default.js
@@ -134,11 +134,10 @@ const SettingsCardSearch = {
 
     const metadataText = this.normalize(card.dataset.searchMetadata || '');
     const fieldsText = this.normalize(card.dataset.searchFields || '');
-    const fallbackText = this.normalize(card.dataset.searchText || '');
 
     return {
-      metadata: metadataText ? metadataText.includes(query) : fallbackText.includes(query),
-      fields: fieldsText ? fieldsText.includes(query) : false,
+      metadata: metadataText.includes(query),
+      fields: fieldsText.includes(query),
     };
   },
 

--- a/src/Resources/public/js/default.js
+++ b/src/Resources/public/js/default.js
@@ -104,4 +104,89 @@ const DefaultFieldManager = {
   }
 };
 
+const SettingsCardSearch = {
+  SELECTORS: {
+    INPUT: '[data-mbiz-settings-search]',
+    CARD: '[data-mbiz-settings-card]',
+    GROUP: '[data-mbiz-settings-group]',
+    EMPTY: '[data-mbiz-settings-search-empty]',
+  },
+
+  CLASSES: {
+    HIDDEN: 'd-none',
+  },
+
+  normalize(value) {
+    return value
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '');
+  },
+
+  filterCards(input, cards, groups, emptyMessage) {
+    const query = this.normalize(input.value.trim());
+    let visibleCardsCount = 0;
+
+    cards.forEach((card) => {
+      const searchText = this.normalize(card.dataset.searchText || '');
+      const isVisible = !query || searchText.includes(query);
+
+      card.classList.toggle(this.CLASSES.HIDDEN, !isVisible);
+
+      if (isVisible) {
+        visibleCardsCount += 1;
+      }
+    });
+
+    groups.forEach((group) => {
+      const hasVisibleCard = Array.from(group.querySelectorAll(this.SELECTORS.CARD))
+        .some((card) => !card.classList.contains(this.CLASSES.HIDDEN));
+
+      group.classList.toggle(this.CLASSES.HIDDEN, !hasVisibleCard);
+    });
+
+    emptyMessage?.classList.toggle(this.CLASSES.HIDDEN, visibleCardsCount > 0);
+  },
+
+  autofocus(input) {
+    window.requestAnimationFrame(() => {
+      if (document.activeElement && document.body !== document.activeElement) {
+        return;
+      }
+
+      input.focus({ preventScroll: true });
+    });
+  },
+
+  init() {
+    const initialize = () => {
+      const input = document.querySelector(this.SELECTORS.INPUT);
+      const cards = document.querySelectorAll(this.SELECTORS.CARD);
+
+      if (!input || 0 === cards.length) {
+        return;
+      }
+
+      const emptyMessage = document.querySelector(this.SELECTORS.EMPTY);
+      const groups = document.querySelectorAll(this.SELECTORS.GROUP);
+
+      input.addEventListener('input', () => {
+        this.filterCards(input, cards, groups, emptyMessage);
+      });
+
+      this.filterCards(input, cards, groups, emptyMessage);
+      this.autofocus(input);
+    };
+
+    if ('loading' === document.readyState) {
+      document.addEventListener('DOMContentLoaded', initialize);
+
+      return;
+    }
+
+    initialize();
+  }
+};
+
 DefaultFieldManager.init();
+SettingsCardSearch.init();

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -18,6 +18,7 @@ monsieurbiz:
             search:
                 placeholder: Search for a setting
                 no_results: No setting matches your search.
+                field_match: Matched a settings field
             use_default_value: Use default value
             form:
                 title:

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -13,6 +13,9 @@ monsieurbiz:
                 title: Settings of %pluginName%
             card:
                 by: by %vendorName%
+            search:
+                placeholder: Search for a setting
+                no_results: No setting matches your search.
             use_default_value: Use default value
             form:
                 title:

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -13,6 +13,8 @@ monsieurbiz:
                 title: Settings of %pluginName%
             card:
                 by: by %vendorName%
+            category:
+                other: Other
             search:
                 placeholder: Search for a setting
                 no_results: No setting matches your search.

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -18,6 +18,7 @@ monsieurbiz:
             search:
                 placeholder: Rechercher un réglage
                 no_results: Aucun réglage ne correspond à votre recherche.
+                field_match: Correspondance trouvée dans un champ
             use_default_value: Utiliser la valeur par défaut
             form:
                 title:

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -13,6 +13,9 @@ monsieurbiz:
                 title: Réglage de %pluginName%
             card:
                 by: par %vendorName%
+            search:
+                placeholder: Rechercher un réglage
+                no_results: Aucun réglage ne correspond à votre recherche.
             use_default_value: Utiliser la valeur par défaut
             form:
                 title:

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -13,6 +13,8 @@ monsieurbiz:
                 title: Réglage de %pluginName%
             card:
                 by: par %vendorName%
+            category:
+                other: Autres
             search:
                 placeholder: Rechercher un réglage
                 no_results: Aucun réglage ne correspond à votre recherche.

--- a/src/Resources/views/admin/settings/index.html.twig
+++ b/src/Resources/views/admin/settings/index.html.twig
@@ -8,5 +8,5 @@
 {% endblock %}
 
 {% block body %}
-    {% hook ['sylius_admin.monsieurbiz_settings.index', 'sylius_admin.common.index'] with { settings: settings } %}
+    {% hook ['sylius_admin.monsieurbiz_settings.index', 'sylius_admin.common.index'] with { settings: settings, settings_search_index: settings_search_index } %}
 {% endblock %}

--- a/src/Resources/views/admin/settings/index.html.twig
+++ b/src/Resources/views/admin/settings/index.html.twig
@@ -2,6 +2,11 @@
 
 {% block title %}{{ 'monsieurbiz.settings.ui.settings.title'|trans }} {{ parent() }}{% endblock %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('bundles/monsieurbizsyliussettingsplugin/css/settings.css') }}">
+{% endblock %}
+
 {% block body %}
     {% hook ['sylius_admin.monsieurbiz_settings.index', 'sylius_admin.common.index'] with { settings: settings } %}
 {% endblock %}

--- a/src/Resources/views/admin/settings/index/content/cards.html.twig
+++ b/src/Resources/views/admin/settings/index/content/cards.html.twig
@@ -1,4 +1,5 @@
 {% set settings = hookable_metadata.context.settings %}
+{% set settings_categories = hookable_metadata.context.settings_categories|default({}) %}
 {% set settings_search_index = hookable_metadata.context.settings_search_index|default({}) %}
 {% set fallback_category = 'monsieurbiz.settings.ui.category.other' %}
 {% set field_match_label = 'monsieurbiz.settings.ui.search.field_match'|trans %}
@@ -6,7 +7,7 @@
 {% set fallback_settings = [] %}
 
 {% for card in settings %}
-    {% set category = card.category|default(null) %}
+    {% set category = settings_categories[card.alias]|default(null) %}
     {% if category is empty or category == fallback_category %}
         {% set fallback_settings = fallback_settings|merge([card]) %}
     {% else %}
@@ -36,9 +37,8 @@
                     {% set search_index = settings_search_index[card.alias]|default({metadata: [], fields: []}) %}
                     {% set metadata_search_terms = search_index.metadata|default([])|merge([displayed_category_label]) %}
                     {% set field_search_terms = search_index.fields|default([]) %}
-                    {% set search_terms = metadata_search_terms|merge(field_search_terms) %}
 
-                    <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-text="{{ search_terms|join(' ')|lower|e('html_attr') }}" data-search-metadata="{{ metadata_search_terms|join(' ')|lower|e('html_attr') }}" data-search-fields="{{ field_search_terms|join(' ')|lower|e('html_attr') }}">
+                    <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-metadata="{{ metadata_search_terms|join(' ')|lower|e('html_attr') }}" data-search-fields="{{ field_search_terms|join(' ')|lower|e('html_attr') }}">
                         <div class="card mbiz-settings-card h-100">
                             <div class="card-body">
                                 <span class="mbiz-settings-card__field-match-indicator d-none" data-mbiz-settings-field-match-indicator aria-hidden="true" title="{{ field_match_label|e('html_attr') }}">

--- a/src/Resources/views/admin/settings/index/content/cards.html.twig
+++ b/src/Resources/views/admin/settings/index/content/cards.html.twig
@@ -1,9 +1,27 @@
 {% set settings = hookable_metadata.context.settings %}
 
-<div class="container-xl">
+<div class="container-xl" data-mbiz-settings-list>
+    <div class="alert alert-info mt-3 d-none" data-mbiz-settings-search-empty>
+        {{ 'monsieurbiz.settings.ui.search.no_results'|trans }}
+    </div>
+
     <div class="row mt-3">
         {% for card in settings %}
-            <div class="col-sm-6 col-lg-3 mb-3">
+            {% set search_terms = [
+                card.alias,
+                card.pluginName|trans,
+                card.vendorName,
+                card.description|trans,
+            ] %}
+
+            {% for path, value in card.defaultValues %}
+                {% set search_terms = search_terms|merge([
+                    path,
+                    value is iterable ? value|json_encode : value,
+                ]) %}
+            {% endfor %}
+
+            <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-text="{{ search_terms|join(' ')|lower|e('html_attr') }}">
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title mb-0">{{ ux_icon(card.icon) }} {{ card.pluginName|trans }}</h5>
@@ -18,6 +36,5 @@
                 </div>
             </div>
         {% endfor %}
-
     </div>
 </div>

--- a/src/Resources/views/admin/settings/index/content/cards.html.twig
+++ b/src/Resources/views/admin/settings/index/content/cards.html.twig
@@ -23,7 +23,10 @@
 
     {% for category_label, category_settings in grouped_settings %}
         <section class="mt-3" data-mbiz-settings-group>
-            <h2 class="h4 mb-3" data-mbiz-settings-group-title>{{ category_label|trans }}</h2>
+            <div class="d-flex align-items-center gap-3 mb-3">
+                <h2 class="h4 mb-0 text-secondary" data-mbiz-settings-group-title>{{ category_label|trans }}</h2>
+                <div class="border-top flex-grow-1" aria-hidden="true"></div>
+            </div>
 
             <div class="row">
                 {% for card in category_settings %}
@@ -44,7 +47,7 @@
                     {% endfor %}
 
                     <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-text="{{ search_terms|join(' ')|lower|e('html_attr') }}">
-                        <div class="card">
+                        <div class="card mbiz-settings-card h-100">
                             <div class="card-body">
                                 <h5 class="card-title mb-0">{{ ux_icon(card.icon) }} {{ card.pluginName|trans }}</h5>
                                 <p class="card-text fs-5 text-secondary">
@@ -53,7 +56,7 @@
                                 <p class="card-text">
                                     {{ card.description|trans }}
                                 </p>
-                                <a href="{{ path('monsieurbiz_sylius_settings_admin_edit', {'alias': card.alias}) }}" class="stretched-link" title=""></a>
+                                <a href="{{ path('monsieurbiz_sylius_settings_admin_edit', {'alias': card.alias}) }}" class="stretched-link" aria-label="{{ card.pluginName|trans|e('html_attr') }}"></a>
                             </div>
                         </div>
                     </div>

--- a/src/Resources/views/admin/settings/index/content/cards.html.twig
+++ b/src/Resources/views/admin/settings/index/content/cards.html.twig
@@ -1,40 +1,64 @@
 {% set settings = hookable_metadata.context.settings %}
+{% set fallback_category = 'monsieurbiz.settings.ui.category.other' %}
+{% set grouped_settings = {} %}
+{% set fallback_settings = [] %}
+
+{% for card in settings %}
+    {% set category = card.category|default(null) %}
+    {% if category is empty or category == fallback_category %}
+        {% set fallback_settings = fallback_settings|merge([card]) %}
+    {% else %}
+        {% set grouped_settings = grouped_settings|merge({ (category): (grouped_settings[category]|default([]))|merge([card]) }) %}
+    {% endif %}
+{% endfor %}
+
+{% if fallback_settings is not empty %}
+    {% set grouped_settings = grouped_settings|merge({ (fallback_category): fallback_settings }) %}
+{% endif %}
 
 <div class="container-xl" data-mbiz-settings-list>
     <div class="alert alert-info mt-3 d-none" data-mbiz-settings-search-empty>
         {{ 'monsieurbiz.settings.ui.search.no_results'|trans }}
     </div>
 
-    <div class="row mt-3">
-        {% for card in settings %}
-            {% set search_terms = [
-                card.alias,
-                card.pluginName|trans,
-                card.vendorName,
-                card.description|trans,
-            ] %}
+    {% for category_label, category_settings in grouped_settings %}
+        <section class="mt-3" data-mbiz-settings-group>
+            <h2 class="h4 mb-3" data-mbiz-settings-group-title>{{ category_label|trans }}</h2>
 
-            {% for path, value in card.defaultValues %}
-                {% set search_terms = search_terms|merge([
-                    path,
-                    value is iterable ? value|json_encode : value,
-                ]) %}
-            {% endfor %}
+            <div class="row">
+                {% for card in category_settings %}
+                    {% set search_terms = [
+                        category_label,
+                        category_label|trans,
+                        card.alias,
+                        card.pluginName|trans,
+                        card.vendorName,
+                        card.description|trans,
+                    ] %}
 
-            <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-text="{{ search_terms|join(' ')|lower|e('html_attr') }}">
-                <div class="card">
-                    <div class="card-body">
-                        <h5 class="card-title mb-0">{{ ux_icon(card.icon) }} {{ card.pluginName|trans }}</h5>
-                        <p class="card-text fs-5 text-secondary">
-                            {{ 'monsieurbiz.settings.ui.card.by'|trans({'%vendorName%': card.vendorName}) }}
-                        </p>
-                        <p class="card-text">
-                            {{ card.description|trans }}
-                        </p>
-                        <a href="{{ path('monsieurbiz_sylius_settings_admin_edit', {'alias': card.alias}) }}" class="stretched-link" title=""></a>
+                    {% for path, value in card.defaultValues %}
+                        {% set search_terms = search_terms|merge([
+                            path,
+                            value is iterable ? value|json_encode : value,
+                        ]) %}
+                    {% endfor %}
+
+                    <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-text="{{ search_terms|join(' ')|lower|e('html_attr') }}">
+                        <div class="card">
+                            <div class="card-body">
+                                <h5 class="card-title mb-0">{{ ux_icon(card.icon) }} {{ card.pluginName|trans }}</h5>
+                                <p class="card-text fs-5 text-secondary">
+                                    {{ 'monsieurbiz.settings.ui.card.by'|trans({'%vendorName%': card.vendorName}) }}
+                                </p>
+                                <p class="card-text">
+                                    {{ card.description|trans }}
+                                </p>
+                                <a href="{{ path('monsieurbiz_sylius_settings_admin_edit', {'alias': card.alias}) }}" class="stretched-link" title=""></a>
+                            </div>
+                        </div>
                     </div>
-                </div>
+                {% endfor %}
             </div>
-        {% endfor %}
-    </div>
+        </section>
+    {% endfor %}
 </div>

--- a/src/Resources/views/admin/settings/index/content/cards.html.twig
+++ b/src/Resources/views/admin/settings/index/content/cards.html.twig
@@ -1,5 +1,7 @@
 {% set settings = hookable_metadata.context.settings %}
+{% set settings_search_index = hookable_metadata.context.settings_search_index|default({}) %}
 {% set fallback_category = 'monsieurbiz.settings.ui.category.other' %}
+{% set field_match_label = 'monsieurbiz.settings.ui.search.field_match'|trans %}
 {% set grouped_settings = {} %}
 {% set fallback_settings = [] %}
 
@@ -22,33 +24,26 @@
     </div>
 
     {% for category_label, category_settings in grouped_settings %}
+        {% set displayed_category_label = category_label|trans %}
         <section class="mt-3" data-mbiz-settings-group>
             <div class="d-flex align-items-center gap-3 mb-3">
-                <h2 class="h4 mb-0 text-secondary" data-mbiz-settings-group-title>{{ category_label|trans }}</h2>
+                <h2 class="h4 mb-0 text-secondary" data-mbiz-settings-group-title>{{ displayed_category_label }}</h2>
                 <div class="border-top flex-grow-1" aria-hidden="true"></div>
             </div>
 
             <div class="row">
                 {% for card in category_settings %}
-                    {% set search_terms = [
-                        category_label,
-                        category_label|trans,
-                        card.alias,
-                        card.pluginName|trans,
-                        card.vendorName,
-                        card.description|trans,
-                    ] %}
+                    {% set search_index = settings_search_index[card.alias]|default({metadata: [], fields: []}) %}
+                    {% set metadata_search_terms = search_index.metadata|default([])|merge([displayed_category_label]) %}
+                    {% set field_search_terms = search_index.fields|default([]) %}
+                    {% set search_terms = metadata_search_terms|merge(field_search_terms) %}
 
-                    {% for path, value in card.defaultValues %}
-                        {% set search_terms = search_terms|merge([
-                            path,
-                            value is iterable ? value|json_encode : value,
-                        ]) %}
-                    {% endfor %}
-
-                    <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-text="{{ search_terms|join(' ')|lower|e('html_attr') }}">
+                    <div class="col-sm-6 col-lg-3 mb-3" data-mbiz-settings-card data-search-text="{{ search_terms|join(' ')|lower|e('html_attr') }}" data-search-metadata="{{ metadata_search_terms|join(' ')|lower|e('html_attr') }}" data-search-fields="{{ field_search_terms|join(' ')|lower|e('html_attr') }}">
                         <div class="card mbiz-settings-card h-100">
                             <div class="card-body">
+                                <span class="mbiz-settings-card__field-match-indicator d-none" data-mbiz-settings-field-match-indicator aria-hidden="true" title="{{ field_match_label|e('html_attr') }}">
+                                    <span class="visually-hidden">{{ field_match_label }}</span>
+                                </span>
                                 <h5 class="card-title mb-0">{{ ux_icon(card.icon) }} {{ card.pluginName|trans }}</h5>
                                 <p class="card-text fs-5 text-secondary">
                                     {{ 'monsieurbiz.settings.ui.card.by'|trans({'%vendorName%': card.vendorName}) }}

--- a/src/Resources/views/admin/settings/index/content/header/title_block/search.html.twig
+++ b/src/Resources/views/admin/settings/index/content/header/title_block/search.html.twig
@@ -1,0 +1,15 @@
+<div class="col-12 col-md-auto">
+    <div class="input-icon">
+        <span class="input-icon-addon">
+            {{ ux_icon('tabler:search') }}
+        </span>
+        <input
+            type="search"
+            class="form-control"
+            placeholder="{{ 'monsieurbiz.settings.ui.search.placeholder'|trans }}"
+            aria-label="{{ 'monsieurbiz.settings.ui.search.placeholder'|trans }}"
+            autofocus
+            data-mbiz-settings-search
+        >
+    </div>
+</div>

--- a/src/Search/SettingsSearchIndexBuilder.php
+++ b/src/Search/SettingsSearchIndexBuilder.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Search;
+
+use MonsieurBiz\SyliusSettingsPlugin\Settings\Settings;
+use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Throwable;
+
+final class SettingsSearchIndexBuilder
+{
+    public function __construct(
+        private FormFactoryInterface $formFactory,
+        private TranslatorInterface $translator,
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    /**
+     * @param iterable<SettingsInterface> $settingsCollection
+     *
+     * @return array<string, array{metadata: list<string>, fields: list<string>}>
+     */
+    public function build(iterable $settingsCollection): array
+    {
+        $index = [];
+
+        foreach ($settingsCollection as $settings) {
+            $index[$settings->getAlias()] = [
+                'metadata' => $this->normalizeTerms($this->extractMetadataTerms($settings)),
+                'fields' => $this->normalizeTerms($this->extractFieldTerms($settings)),
+            ];
+        }
+
+        return $index;
+    }
+
+    /**
+     * @return list<string|null>
+     */
+    private function extractMetadataTerms(SettingsInterface $settings): array
+    {
+        return [
+            $settings->getAlias(),
+            $settings->getVendorName(),
+            $settings->getPluginName(),
+            $settings->getCategory(),
+            $settings->getDescription(),
+            $this->translate($settings->getPluginName()),
+            $this->translate($settings->getCategory()),
+            $this->translate($settings->getDescription()),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractFieldTerms(SettingsInterface $settings): array
+    {
+        try {
+            $form = $this->createIntrospectionForm($settings);
+
+            return $this->extractFormViewTerms($form->createView());
+        } catch (Throwable $throwable) {
+            $this->logger?->debug('Unable to build settings search field index.', [
+                'settings_alias' => $settings->getAlias(),
+                'form_class' => $settings->getFormClass(),
+                'throwable_class' => $throwable::class,
+            ]);
+
+            return [];
+        }
+    }
+
+    private function createIntrospectionForm(SettingsInterface $settings): FormInterface
+    {
+        $options = [
+            'settings' => $settings,
+            'channel' => null,
+            'show_default_checkboxes' => false,
+            'csrf_protection' => false,
+        ];
+
+        try {
+            return $this->formFactory->create($settings->getFormClass(), [], $options);
+            // @phpstan-ignore-next-line FormFactoryInterface does not expose configured type extensions/options.
+        } catch (UndefinedOptionsException) {
+            unset($options['csrf_protection']);
+
+            return $this->formFactory->create($settings->getFormClass(), [], $options);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractFormViewTerms(FormView $view, string $parentPath = ''): array
+    {
+        $terms = [];
+
+        foreach ($view->children as $child) {
+            $name = (string) $child->vars['name'];
+            $path = '' === $parentPath ? $name : $parentPath . '.' . $name;
+
+            if (!$this->shouldIndex($child)) {
+                $terms = [...$terms, ...$this->extractFormViewTerms($child, $path)];
+
+                continue;
+            }
+
+            $terms[] = $name;
+            $terms[] = $path;
+            $terms[] = $this->getLabel($child, $name);
+            $terms[] = $this->getTranslatedFormVar($child, 'help', 'help_translation_parameters', 'help_translation_domain');
+            $terms[] = $this->getTranslatedPlaceholder($child);
+            $terms = [...$terms, ...$this->extractFormViewTerms($child, $path)];
+        }
+
+        return $terms;
+    }
+
+    private function shouldIndex(FormView $view): bool
+    {
+        $name = (string) $view->vars['name'];
+        if ('_token' === $name || str_contains($name, '___' . Settings::DEFAULT_KEY)) {
+            return false;
+        }
+
+        $blockPrefixes = $view->vars['block_prefixes'] ?? [];
+        if (!\is_array($blockPrefixes)) {
+            return true;
+        }
+
+        return [] === array_intersect($blockPrefixes, ['button', 'submit', 'reset', 'hidden', 'csrf_token']);
+    }
+
+    private function getLabel(FormView $view, string $fallbackName): string
+    {
+        if (false === $view->vars['label']) {
+            return '';
+        }
+
+        $label = $view->vars['label'] ?? $this->humanize($fallbackName);
+
+        return $this->translate(
+            \is_string($label) ? $label : (string) $label,
+            $view->vars['label_translation_parameters'] ?? [],
+            $view->vars['translation_domain'] ?? null,
+        );
+    }
+
+    private function getTranslatedPlaceholder(FormView $view): string
+    {
+        $placeholder = $view->vars['attr']['placeholder'] ?? $view->vars['placeholder'] ?? null;
+        if (null === $placeholder || false === $placeholder) {
+            return '';
+        }
+
+        return $this->translate(
+            \is_string($placeholder) ? $placeholder : (string) $placeholder,
+            $view->vars['attr_translation_parameters'] ?? [],
+            $view->vars['translation_domain'] ?? null,
+        );
+    }
+
+    private function getTranslatedFormVar(FormView $view, string $valueKey, string $parametersKey, string $domainKey): string
+    {
+        $value = $view->vars[$valueKey] ?? null;
+        if (null === $value || false === $value) {
+            return '';
+        }
+
+        return $this->translate(
+            \is_string($value) ? $value : (string) $value,
+            $view->vars[$parametersKey] ?? [],
+            $view->vars[$domainKey] ?? $view->vars['translation_domain'] ?? null,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function translate(?string $message, array $parameters = [], string|false|null $domain = null): string
+    {
+        if (null === $message || '' === $message) {
+            return '';
+        }
+
+        $translated = false === $domain ? $message : $this->translator->trans($message, $parameters, $domain);
+
+        return strip_tags($translated);
+    }
+
+    /**
+     * @param list<string|null> $terms
+     *
+     * @return list<string>
+     */
+    private function normalizeTerms(array $terms): array
+    {
+        $normalizedTerms = [];
+        foreach ($terms as $term) {
+            if (null === $term) {
+                continue;
+            }
+
+            $term = trim((string) $term);
+            if ('' !== $term) {
+                $normalizedTerms[] = $term;
+            }
+        }
+
+        return array_values(array_unique($normalizedTerms));
+    }
+
+    private function humanize(string $text): string
+    {
+        return ucfirst(strtolower(trim((string) preg_replace(['/([A-Z])/', '/[_\s]+/'], ['_$1', ' '], $text))));
+    }
+}

--- a/src/Search/SettingsSearchIndexBuilder.php
+++ b/src/Search/SettingsSearchIndexBuilder.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusSettingsPlugin\Search;
 
+use MonsieurBiz\SyliusSettingsPlugin\Settings\CategorizedSettingsInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\Settings;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -28,6 +30,7 @@ final class SettingsSearchIndexBuilder
     public function __construct(
         private FormFactoryInterface $formFactory,
         private TranslatorInterface $translator,
+        private CacheItemPoolInterface $settingsSearchCache,
         private ?LoggerInterface $logger = null,
     ) {
     }
@@ -42,9 +45,11 @@ final class SettingsSearchIndexBuilder
         $index = [];
 
         foreach ($settingsCollection as $settings) {
+            $fields = $this->extractFieldTerms($settings);
+
             $index[$settings->getAlias()] = [
                 'metadata' => $this->normalizeTerms($this->extractMetadataTerms($settings)),
-                'fields' => $this->normalizeTerms($this->extractFieldTerms($settings)),
+                'fields' => $fields,
             ];
         }
 
@@ -56,14 +61,16 @@ final class SettingsSearchIndexBuilder
      */
     private function extractMetadataTerms(SettingsInterface $settings): array
     {
+        $category = $settings instanceof CategorizedSettingsInterface ? $settings->getCategory() : null;
+
         return [
             $settings->getAlias(),
             $settings->getVendorName(),
             $settings->getPluginName(),
-            $settings->getCategory(),
+            $category,
             $settings->getDescription(),
             $this->translate($settings->getPluginName()),
-            $this->translate($settings->getCategory()),
+            $this->translate($category),
             $this->translate($settings->getDescription()),
         ];
     }
@@ -73,14 +80,30 @@ final class SettingsSearchIndexBuilder
      */
     private function extractFieldTerms(SettingsInterface $settings): array
     {
-        try {
-            $form = $this->createIntrospectionForm($settings);
+        $formClass = null;
 
-            return $this->extractFormViewTerms($form->createView());
+        try {
+            $formClass = $settings->getFormClass();
+            $cacheKey = $this->getFieldTermsCacheKey($settings, $formClass);
+            $cacheItem = $this->settingsSearchCache->getItem($cacheKey);
+            if ($cacheItem->isHit()) {
+                $fields = $cacheItem->get();
+
+                return \is_array($fields) ? $fields : [];
+            }
+
+            $form = $this->createIntrospectionForm($settings, $formClass);
+
+            $fields = $this->normalizeTerms($this->extractFormViewTerms($form->createView()));
+
+            $cacheItem->set($fields);
+            $this->settingsSearchCache->save($cacheItem);
+
+            return $fields;
         } catch (Throwable $throwable) {
-            $this->logger?->debug('Unable to build settings search field index.', [
+            $this->logger?->warning('Unable to build settings search field index.', [
                 'settings_alias' => $settings->getAlias(),
-                'form_class' => $settings->getFormClass(),
+                'form_class' => $formClass,
                 'throwable_class' => $throwable::class,
             ]);
 
@@ -88,7 +111,22 @@ final class SettingsSearchIndexBuilder
         }
     }
 
-    private function createIntrospectionForm(SettingsInterface $settings): FormInterface
+    /**
+     * @param class-string $formClass
+     */
+    private function getFieldTermsCacheKey(SettingsInterface $settings, string $formClass): string
+    {
+        return 'settings_search_fields_' . hash('sha256', implode('|', [
+            $settings->getAlias(),
+            $formClass,
+            $this->translator->getLocale(),
+        ]));
+    }
+
+    /**
+     * @param class-string $formClass
+     */
+    private function createIntrospectionForm(SettingsInterface $settings, string $formClass): FormInterface
     {
         $options = [
             'settings' => $settings,
@@ -98,12 +136,12 @@ final class SettingsSearchIndexBuilder
         ];
 
         try {
-            return $this->formFactory->create($settings->getFormClass(), [], $options);
+            return $this->formFactory->create($formClass, [], $options);
             // @phpstan-ignore-next-line FormFactoryInterface does not expose configured type extensions/options.
         } catch (UndefinedOptionsException) {
             unset($options['csrf_protection']);
 
-            return $this->formFactory->create($settings->getFormClass(), [], $options);
+            return $this->formFactory->create($formClass, [], $options);
         }
     }
 

--- a/src/Settings/CategorizedSettingsInterface.php
+++ b/src/Settings/CategorizedSettingsInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Settings;
+
+interface CategorizedSettingsInterface extends SettingsInterface
+{
+    public function getCategory(): ?string;
+}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -64,6 +64,21 @@ final class Settings implements SettingsInterface
         return (string) $this->metadata->getParameter('plugin_name');
     }
 
+    public function getCategory(): ?string
+    {
+        if (!$this->metadata->hasParameter('category')) {
+            return null;
+        }
+
+        $category = $this->metadata->getParameter('category');
+
+        if (null === $category) {
+            return null;
+        }
+
+        return \is_scalar($category) ? (string) $category : null;
+    }
+
     public function getDescription(): ?string
     {
         /** @phpstan-ignore-next-line */

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
-final class Settings implements SettingsInterface
+final class Settings implements CategorizedSettingsInterface
 {
     public const DEFAULT_KEY = 'default';
 

--- a/src/Settings/SettingsInterface.php
+++ b/src/Settings/SettingsInterface.php
@@ -37,8 +37,6 @@ interface SettingsInterface
 
     public function getPluginName(): ?string;
 
-    public function getCategory(): ?string;
-
     public function getDescription(): ?string;
 
     public function getIcon(): ?string;

--- a/src/Settings/SettingsInterface.php
+++ b/src/Settings/SettingsInterface.php
@@ -37,6 +37,8 @@ interface SettingsInterface
 
     public function getPluginName(): ?string;
 
+    public function getCategory(): ?string;
+
     public function getDescription(): ?string;
 
     public function getIcon(): ?string;

--- a/tests/Unit/Command/ClearSettingsSearchCacheCommandTest.php
+++ b/tests/Unit/Command/ClearSettingsSearchCacheCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Tests\Unit\Command;
+
+use BadMethodCallException;
+use MonsieurBiz\SyliusSettingsPlugin\Command\ClearSettingsSearchCacheCommand;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ClearSettingsSearchCacheCommandTest extends TestCase
+{
+    public function testItClearsOnlyInjectedSearchCachePool(): void
+    {
+        $searchCache = new SpyCacheItemPool();
+        $settingsValueCache = new SpyCacheItemPool();
+        $commandTester = new CommandTester(new ClearSettingsSearchCacheCommand($searchCache));
+
+        $exitCode = $commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame(1, $searchCache->clearCalls);
+        self::assertSame(0, $settingsValueCache->clearCalls);
+        self::assertStringContainsString('Settings search cache cleared.', $commandTester->getDisplay());
+    }
+
+    public function testItReturnsFailureWhenPoolCannotBeCleared(): void
+    {
+        $searchCache = new SpyCacheItemPool(false);
+        $commandTester = new CommandTester(new ClearSettingsSearchCacheCommand($searchCache));
+
+        $exitCode = $commandTester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertSame(1, $searchCache->clearCalls);
+        self::assertStringContainsString('Unable to clear the settings search cache.', $commandTester->getDisplay());
+    }
+}
+
+final class SpyCacheItemPool implements CacheItemPoolInterface
+{
+    public int $clearCalls = 0;
+
+    public function __construct(private bool $clearResult = true)
+    {
+    }
+
+    public function getItem(string $key): CacheItemInterface
+    {
+        throw new BadMethodCallException('Not used.');
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return [];
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return false;
+    }
+
+    public function clear(): bool
+    {
+        ++$this->clearCalls;
+
+        return $this->clearResult;
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        return true;
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return true;
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Tests\Unit\DependencyInjection;
+
+use MonsieurBiz\SyliusSettingsPlugin\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+
+final class ConfigurationTest extends TestCase
+{
+    public function testItAcceptsPluginCategory(): void
+    {
+        $config = $this->processConfiguration([
+            'plugins' => [
+                'app.fake_blog' => $this->getPluginConfiguration([
+                    'category' => 'Content',
+                ]),
+            ],
+        ]);
+
+        self::assertSame('Content', $config['plugins']['app.fake_blog']['category']);
+    }
+
+    public function testItKeepsPluginCategoryNullWhenMissing(): void
+    {
+        $config = $this->processConfiguration([
+            'plugins' => [
+                'app.fake_blog' => $this->getPluginConfiguration(),
+            ],
+        ]);
+
+        self::assertNull($config['plugins']['app.fake_blog']['category']);
+    }
+
+    private function processConfiguration(array $config): array
+    {
+        return (new Processor())->processConfiguration(new Configuration(), [$config]);
+    }
+
+    private function getPluginConfiguration(array $config = []): array
+    {
+        return array_replace([
+            'vendor_name' => 'Fake Fixtures',
+            'vendor_url' => null,
+            'plugin_name' => 'Fake Blog Settings',
+            'description' => 'Blog configuration for testing.',
+            'icon' => 'tabler:article',
+            'use_locales' => true,
+            'classes' => [
+                'form' => 'App\\Form\\SettingsType',
+            ],
+            'default_values' => [
+                'enabled' => true,
+            ],
+        ], $config);
+    }
+}

--- a/tests/Unit/DependencyInjection/MonsieurBizSyliusSettingsExtensionTest.php
+++ b/tests/Unit/DependencyInjection/MonsieurBizSyliusSettingsExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Tests\Unit\DependencyInjection;
+
+use MonsieurBiz\SyliusSettingsPlugin\DependencyInjection\MonsieurBizSyliusSettingsExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class MonsieurBizSyliusSettingsExtensionTest extends TestCase
+{
+    public function testItPrependsSearchCachePoolWhenDoctrineMigrationsPrependIsDisabled(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('sylius_core.prepend_doctrine_migrations', false);
+
+        (new MonsieurBizSyliusSettingsExtension())->prepend($container);
+
+        $frameworkConfigs = $container->getExtensionConfig('framework');
+        $doctrineMigrationsConfigs = $container->getExtensionConfig('doctrine_migrations');
+
+        self::assertSame([], $doctrineMigrationsConfigs);
+        self::assertArrayHasKey('cache', $frameworkConfigs[0]);
+        self::assertSame([
+            'adapter' => 'cache.adapter.array',
+            'public' => false,
+            'tags' => true,
+        ], $frameworkConfigs[0]['cache']['pools']['monsieurbiz_settings.cache']);
+        self::assertSame([
+            'adapter' => 'cache.adapter.array',
+            'public' => false,
+        ], $frameworkConfigs[0]['cache']['pools']['monsieurbiz_settings.search_cache']);
+    }
+}

--- a/tests/Unit/Search/SettingsSearchIndexBuilderTest.php
+++ b/tests/Unit/Search/SettingsSearchIndexBuilderTest.php
@@ -18,11 +18,13 @@ require_once __DIR__ . '/../../../dist/src/Form/FakeSettingsType.php';
 use Error;
 use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsType;
 use MonsieurBiz\SyliusSettingsPlugin\Search\SettingsSearchIndexBuilder;
+use MonsieurBiz\SyliusSettingsPlugin\Settings\CategorizedSettingsInterface;
 use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
 use Stringable;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\CoreExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -43,6 +45,7 @@ final class SettingsSearchIndexBuilderTest extends TestCase
                 ->addTypeExtension(new SearchSettingsTypeExtension())
                 ->getFormFactory(),
             $this->createTranslator(),
+            new ArrayAdapter(),
             new NullLogger(),
         );
 
@@ -72,6 +75,7 @@ final class SettingsSearchIndexBuilderTest extends TestCase
         $builder = new SettingsSearchIndexBuilder(
             Forms::createFormFactoryBuilder()->addExtension(new CoreExtension())->getFormFactory(),
             $this->createTranslator(),
+            new ArrayAdapter(),
             new NullLogger(),
         );
 
@@ -102,6 +106,7 @@ final class SettingsSearchIndexBuilderTest extends TestCase
                 ->addType(new \App\Form\FakeSettingsType())
                 ->getFormFactory(),
             $this->createTranslator(),
+            new ArrayAdapter(),
             new NullLogger(),
         );
 
@@ -131,6 +136,7 @@ final class SettingsSearchIndexBuilderTest extends TestCase
                 ->addType(new ThrowingSearchSettingsType())
                 ->getFormFactory(),
             $this->createTranslator(),
+            new ArrayAdapter(),
             new NullLogger(),
         );
 
@@ -148,6 +154,7 @@ final class SettingsSearchIndexBuilderTest extends TestCase
                 ->addType(new ThrowingSearchSettingsType())
                 ->getFormFactory(),
             $this->createTranslator(),
+            new ArrayAdapter(),
             $logger,
         );
 
@@ -155,6 +162,7 @@ final class SettingsSearchIndexBuilderTest extends TestCase
 
         self::assertCount(1, $logger->logs);
         self::assertSame('Unable to build settings search field index.', $logger->logs[0]['message']);
+        self::assertSame('warning', $logger->logs[0]['level']);
         self::assertSame([
             'settings_alias' => 'app.blog',
             'form_class' => ThrowingSearchSettingsType::class,
@@ -164,12 +172,145 @@ final class SettingsSearchIndexBuilderTest extends TestCase
         self::assertStringNotContainsString('sensitive-token', json_encode($logger->logs[0]['context'], \JSON_THROW_ON_ERROR));
     }
 
+    public function testItKeepsSettingsWithoutCategoryUsable(): void
+    {
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new SearchSettingsType())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+
+        $settings = $this->createMock(SettingsInterface::class);
+        $settings->method('getAlias')->willReturn('app.custom');
+        $settings->method('getVendorName')->willReturn('Acme');
+        $settings->method('getPluginName')->willReturn('Custom settings');
+        $settings->method('getDescription')->willReturn('Custom description');
+        $settings->method('getFormClass')->willReturn(SearchSettingsType::class);
+
+        $index = $builder->build([$settings]);
+
+        self::assertArrayHasKey('app.custom', $index);
+        self::assertSame([
+            'app.custom',
+            'Acme',
+            'Custom settings',
+            'Custom description',
+        ], $index['app.custom']['metadata']);
+        self::assertContains('title', $index['app.custom']['fields']);
+    }
+
+    public function testItCachesFieldTermsForSameAliasFormClassAndLocale(): void
+    {
+        CountingSearchSettingsType::$builds = 0;
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new CountingSearchSettingsType())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+
+        $settings = $this->createSettings(CountingSearchSettingsType::class);
+
+        $builder->build([$settings]);
+        $builder->build([$settings]);
+
+        self::assertSame(1, CountingSearchSettingsType::$builds);
+    }
+
+    public function testItUsesSeparateFieldCacheEntriesForDifferentLocales(): void
+    {
+        CountingSearchSettingsType::$builds = 0;
+        $translator = new MutableTranslator('en');
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new CountingSearchSettingsType())
+                ->getFormFactory(),
+            $translator,
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+
+        $settings = $this->createSettings(CountingSearchSettingsType::class);
+
+        $builder->build([$settings]);
+        $translator->locale = 'fr';
+        $builder->build([$settings]);
+
+        self::assertSame(2, CountingSearchSettingsType::$builds);
+    }
+
+    public function testItUsesSeparateFieldCacheEntriesForDifferentAliasesAndFormClasses(): void
+    {
+        CountingSearchSettingsType::$builds = 0;
+        AlternateCountingSearchSettingsType::$builds = 0;
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new CountingSearchSettingsType())
+                ->addType(new AlternateCountingSearchSettingsType())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+
+        $builder->build([
+            $this->createSettings(CountingSearchSettingsType::class, 'app.first'),
+            $this->createSettings(CountingSearchSettingsType::class, 'app.second'),
+            $this->createSettings(AlternateCountingSearchSettingsType::class, 'app.first'),
+        ]);
+
+        self::assertSame(2, CountingSearchSettingsType::$builds);
+        self::assertSame(1, AlternateCountingSearchSettingsType::$builds);
+    }
+
+    public function testItDoesNotCacheMetadataTerms(): void
+    {
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new CountingSearchSettingsType())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+
+        $settings = $this->createMock(CategorizedSettingsInterface::class);
+        $settings->method('getAlias')->willReturn('app.blog');
+        $settings->method('getVendorName')->willReturn('Acme');
+        $settings->method('getCategory')->willReturn('Content');
+        $settings->method('getDescription')->willReturn('Description');
+        $settings->method('getFormClass')->willReturn(CountingSearchSettingsType::class);
+        $pluginName = 'First name';
+        $settings->method('getPluginName')->willReturnCallback(static function () use (&$pluginName): string {
+            return $pluginName;
+        });
+
+        $index = $builder->build([$settings]);
+        self::assertContains('First name', $index['app.blog']['metadata']);
+
+        $pluginName = 'Second name';
+        $index = $builder->build([$settings]);
+
+        self::assertContains('Second name', $index['app.blog']['metadata']);
+        self::assertNotContains('First name', $index['app.blog']['metadata']);
+    }
+
     /**
      * @param class-string $formClass
      */
     private function createSettings(string $formClass = SearchSettingsType::class, string $alias = 'app.blog'): SettingsInterface
     {
-        $settings = $this->createMock(SettingsInterface::class);
+        $settings = $this->createMock(CategorizedSettingsInterface::class);
         $settings->method('getAlias')->willReturn($alias);
         $settings->method('getVendorName')->willReturn('Acme');
         $settings->method('getPluginName')->willReturn('Blog settings');
@@ -182,17 +323,24 @@ final class SettingsSearchIndexBuilderTest extends TestCase
 
     private function createTranslator(): TranslatorInterface
     {
-        return new class() implements TranslatorInterface {
-            public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
-            {
-                return strtr($id, $parameters);
-            }
+        return new MutableTranslator('en');
+    }
+}
 
-            public function getLocale(): string
-            {
-                return 'en';
-            }
-        };
+final class MutableTranslator implements TranslatorInterface
+{
+    public function __construct(public string $locale)
+    {
+    }
+
+    public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+    {
+        return strtr($id, $parameters);
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
     }
 }
 
@@ -248,6 +396,28 @@ final class ThrowingSearchSettingsType extends AbstractSettingsType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         throw new Error('sensitive-token must not be logged');
+    }
+}
+
+final class CountingSearchSettingsType extends AbstractSettingsType
+{
+    public static int $builds = 0;
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        ++self::$builds;
+        $builder->add('counted_field', TextType::class, ['label' => 'Counted field']);
+    }
+}
+
+final class AlternateCountingSearchSettingsType extends AbstractSettingsType
+{
+    public static int $builds = 0;
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        ++self::$builds;
+        $builder->add('alternate_counted_field', TextType::class, ['label' => 'Alternate counted field']);
     }
 }
 

--- a/tests/Unit/Search/SettingsSearchIndexBuilderTest.php
+++ b/tests/Unit/Search/SettingsSearchIndexBuilderTest.php
@@ -1,0 +1,273 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Tests\Unit\Search;
+
+require_once __DIR__ . '/../../../dist/src/Form/FakeSettingsType.php';
+
+use Error;
+use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsType;
+use MonsieurBiz\SyliusSettingsPlugin\Search\SettingsSearchIndexBuilder;
+use MonsieurBiz\SyliusSettingsPlugin\Settings\SettingsInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\NullLogger;
+use Stringable;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\CoreExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Forms;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class SettingsSearchIndexBuilderTest extends TestCase
+{
+    public function testItSeparatesMetadataAndFormFieldTerms(): void
+    {
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new SearchSettingsType())
+                ->addTypeExtension(new SearchSettingsTypeExtension())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            new NullLogger(),
+        );
+
+        $index = $builder->build([$this->createSettings()]);
+
+        self::assertArrayHasKey('app.blog', $index);
+        self::assertSame([
+            'app.blog',
+            'Acme',
+            'Blog settings',
+            'Content',
+            'Configure the blog',
+        ], $index['app.blog']['metadata']);
+
+        self::assertContains('title', $index['app.blog']['fields']);
+        self::assertContains('Title label', $index['app.blog']['fields']);
+        self::assertContains('Type a title', $index['app.blog']['fields']);
+        self::assertContains('Shown on the storefront', $index['app.blog']['fields']);
+        self::assertContains('nested.child_name', $index['app.blog']['fields']);
+        self::assertContains('Child name', $index['app.blog']['fields']);
+        self::assertContains('Extension field', $index['app.blog']['fields']);
+        self::assertContains('Without label', $index['app.blog']['fields']);
+    }
+
+    public function testItDoesNotIndexSavedDataOrDefaultValues(): void
+    {
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()->addExtension(new CoreExtension())->getFormFactory(),
+            $this->createTranslator(),
+            new NullLogger(),
+        );
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject&SettingsInterface $settings */
+        $settings = $this->createSettings();
+        $settings
+            ->expects(self::never())
+            ->method('getDefaultValues')
+        ;
+        $settings
+            ->expects(self::never())
+            ->method('getSettingsValuesByChannelAndLocale')
+        ;
+
+        $index = $builder->build([$settings]);
+        $fieldTerms = implode(' ', $index['app.blog']['fields']);
+
+        self::assertStringNotContainsString('saved database value', $fieldTerms);
+        self::assertStringNotContainsString('default metadata value', $fieldTerms);
+        self::assertStringNotContainsString('technical_secret', $fieldTerms);
+    }
+
+    public function testItIndexesDistinctFakeSettingsFieldsByAlias(): void
+    {
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new \App\Form\FakeSettingsType())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            new NullLogger(),
+        );
+
+        $index = $builder->build([
+            $this->createSettings(\App\Form\FakeSettingsType::class, 'app.fake_blog'),
+            $this->createSettings(\App\Form\FakeSettingsType::class, 'app.fake_payment'),
+        ]);
+
+        self::assertContains('blog_headline', $index['app.fake_blog']['fields']);
+        self::assertContains('Blog headline', $index['app.fake_blog']['fields']);
+        self::assertContains('Enter the blog landing headline', $index['app.fake_blog']['fields']);
+        self::assertContains('Shown above the latest blog articles.', $index['app.fake_blog']['fields']);
+        self::assertNotContains('payment_retry_limit', $index['app.fake_blog']['fields']);
+
+        self::assertContains('payment_retry_limit', $index['app.fake_payment']['fields']);
+        self::assertContains('Payment retry limit', $index['app.fake_payment']['fields']);
+        self::assertContains('Maximum payment retries', $index['app.fake_payment']['fields']);
+        self::assertContains('Limits how many times a failed payment is retried.', $index['app.fake_payment']['fields']);
+        self::assertNotContains('blog_headline', $index['app.fake_payment']['fields']);
+    }
+
+    public function testItIgnoresThrowableRaisedDuringFormIntrospection(): void
+    {
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new ThrowingSearchSettingsType())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            new NullLogger(),
+        );
+
+        $index = $builder->build([$this->createSettings(ThrowingSearchSettingsType::class)]);
+
+        self::assertSame([], $index['app.blog']['fields']);
+    }
+
+    public function testItDoesNotLogThrowableMessage(): void
+    {
+        $logger = new InMemoryLogger();
+        $builder = new SettingsSearchIndexBuilder(
+            Forms::createFormFactoryBuilder()
+                ->addExtension(new CoreExtension())
+                ->addType(new ThrowingSearchSettingsType())
+                ->getFormFactory(),
+            $this->createTranslator(),
+            $logger,
+        );
+
+        $builder->build([$this->createSettings(ThrowingSearchSettingsType::class)]);
+
+        self::assertCount(1, $logger->logs);
+        self::assertSame('Unable to build settings search field index.', $logger->logs[0]['message']);
+        self::assertSame([
+            'settings_alias' => 'app.blog',
+            'form_class' => ThrowingSearchSettingsType::class,
+            'throwable_class' => Error::class,
+        ], $logger->logs[0]['context']);
+        self::assertStringNotContainsString('sensitive-token', $logger->logs[0]['message']);
+        self::assertStringNotContainsString('sensitive-token', json_encode($logger->logs[0]['context'], \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param class-string $formClass
+     */
+    private function createSettings(string $formClass = SearchSettingsType::class, string $alias = 'app.blog'): SettingsInterface
+    {
+        $settings = $this->createMock(SettingsInterface::class);
+        $settings->method('getAlias')->willReturn($alias);
+        $settings->method('getVendorName')->willReturn('Acme');
+        $settings->method('getPluginName')->willReturn('Blog settings');
+        $settings->method('getCategory')->willReturn('Content');
+        $settings->method('getDescription')->willReturn('Configure the blog');
+        $settings->method('getFormClass')->willReturn($formClass);
+
+        return $settings;
+    }
+
+    private function createTranslator(): TranslatorInterface
+    {
+        return new class() implements TranslatorInterface {
+            public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+            {
+                return strtr($id, $parameters);
+            }
+
+            public function getLocale(): string
+            {
+                return 'en';
+            }
+        };
+    }
+}
+
+final class SearchSettingsType extends AbstractSettingsType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class, [
+                'label' => 'Title label',
+                'attr' => [
+                    'placeholder' => 'Type a title',
+                ],
+                'help' => 'Shown on the storefront',
+                'data' => 'saved database value',
+            ])
+            ->add('without_label', TextType::class)
+            ->add('technical_secret', HiddenType::class, [
+                'data' => 'technical_secret',
+            ])
+            ->add('title___default', TextType::class)
+            ->add('nested', FormType::class, [
+                'label' => 'Nested group',
+            ])
+        ;
+
+        $builder->get('nested')->add('child_name', TextType::class, [
+            'label' => 'Child name',
+        ]);
+    }
+}
+
+final class SearchSettingsTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('extension_field', TextType::class, [
+            'label' => 'Extension field',
+        ]);
+    }
+
+    /**
+     * @return iterable<class-string>
+     */
+    public static function getExtendedTypes(): iterable
+    {
+        return [SearchSettingsType::class];
+    }
+}
+
+final class ThrowingSearchSettingsType extends AbstractSettingsType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        throw new Error('sensitive-token must not be logged');
+    }
+}
+
+final class InMemoryLogger extends AbstractLogger
+{
+    /**
+     * @var list<array{level: mixed, message: string, context: array<string, mixed>}>
+     */
+    public array $logs = [];
+
+    /**
+     * @param array<string, mixed> $context
+     * @param mixed $level
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/tests/Unit/Twig/SettingsCardsTemplateTest.php
+++ b/tests/Unit/Twig/SettingsCardsTemplateTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Settings plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSettingsPlugin\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\TranslationExtension;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
+
+final class SettingsCardsTemplateTest extends TestCase
+{
+    public function testItAddsDisplayedCategoryLabelsToSearchMetadata(): void
+    {
+        $twig = new Environment(new FilesystemLoader(\dirname(__DIR__, 3) . '/src/Resources/views'));
+        $twig->addExtension(new TranslationExtension($this->createTranslator()));
+        $twig->addFunction(new TwigFunction('ux_icon', static fn (?string $icon): string => ''));
+        $twig->addFunction(new TwigFunction('path', static fn (string $route, array $parameters = []): string => '#'));
+
+        $html = $twig->render('admin/settings/index/content/cards.html.twig', [
+            'hookable_metadata' => [
+                'context' => [
+                    'settings' => [
+                        [
+                            'alias' => 'app.explicit',
+                            'category' => 'app.category.content',
+                            'icon' => null,
+                            'pluginName' => 'Explicit settings',
+                            'vendorName' => 'Acme',
+                            'description' => 'Explicit description',
+                        ],
+                        [
+                            'alias' => 'app.fallback',
+                            'category' => null,
+                            'icon' => null,
+                            'pluginName' => 'Fallback settings',
+                            'vendorName' => 'Acme',
+                            'description' => 'Fallback description',
+                        ],
+                    ],
+                    'settings_search_index' => [
+                        'app.explicit' => ['metadata' => ['explicit metadata'], 'fields' => []],
+                        'app.fallback' => ['metadata' => ['fallback metadata'], 'fields' => []],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertStringContainsString('data-search-metadata="explicit&#x20;metadata&#x20;content&#x20;label"', $html);
+        self::assertStringContainsString('data-search-metadata="fallback&#x20;metadata&#x20;other"', $html);
+        self::assertStringContainsString('data-search-text="explicit&#x20;metadata&#x20;content&#x20;label"', $html);
+        self::assertStringContainsString('data-search-text="fallback&#x20;metadata&#x20;other"', $html);
+    }
+
+    private function createTranslator(): TranslatorInterface
+    {
+        return new class() implements TranslatorInterface {
+            public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+            {
+                return strtr($id, [
+                    'app.category.content' => 'Content label',
+                    'monsieurbiz.settings.ui.category.other' => 'Other',
+                ] + $parameters);
+            }
+
+            public function getLocale(): string
+            {
+                return 'en';
+            }
+        };
+    }
+}

--- a/tests/Unit/Twig/SettingsCardsTemplateTest.php
+++ b/tests/Unit/Twig/SettingsCardsTemplateTest.php
@@ -35,7 +35,6 @@ final class SettingsCardsTemplateTest extends TestCase
                     'settings' => [
                         [
                             'alias' => 'app.explicit',
-                            'category' => 'app.category.content',
                             'icon' => null,
                             'pluginName' => 'Explicit settings',
                             'vendorName' => 'Acme',
@@ -43,12 +42,15 @@ final class SettingsCardsTemplateTest extends TestCase
                         ],
                         [
                             'alias' => 'app.fallback',
-                            'category' => null,
                             'icon' => null,
                             'pluginName' => 'Fallback settings',
                             'vendorName' => 'Acme',
                             'description' => 'Fallback description',
                         ],
+                    ],
+                    'settings_categories' => [
+                        'app.explicit' => 'app.category.content',
+                        'app.fallback' => null,
                     ],
                     'settings_search_index' => [
                         'app.explicit' => ['metadata' => ['explicit metadata'], 'fields' => []],
@@ -60,8 +62,8 @@ final class SettingsCardsTemplateTest extends TestCase
 
         self::assertStringContainsString('data-search-metadata="explicit&#x20;metadata&#x20;content&#x20;label"', $html);
         self::assertStringContainsString('data-search-metadata="fallback&#x20;metadata&#x20;other"', $html);
-        self::assertStringContainsString('data-search-text="explicit&#x20;metadata&#x20;content&#x20;label"', $html);
-        self::assertStringContainsString('data-search-text="fallback&#x20;metadata&#x20;other"', $html);
+        self::assertStringContainsString('data-search-fields=""', $html);
+        self::assertStringNotContainsString('data-search-text=', $html);
     }
 
     private function createTranslator(): TranslatorInterface


### PR DESCRIPTION
## Summary

- Add live, accent-insensitive settings search with autofocus and a no-results state. Search covers setting metadata plus real form field names, labels, placeholders, and help text.
- Cache normalized field metadata in a dedicated pool, keyed by settings alias, form class, and locale.
- Keep stored and default setting values out of the search index.
- Show a primary-colored dot when a result matches a form field.
- Group settings by optional categories and place uncategorized settings under an `Other` fallback.
- Avoid duplicated search content by using `data-search-metadata` and `data-search-fields` without `data-search-text`.
- Add theme-aware hover and focus feedback to setting cards, with clearer section separators and accessible link labels.
- Give each fake development setting a distinct form field for realistic search testing.

## Configuration

```yaml
monsieurbiz_sylius_settings:
    plugins:
        app.example:
            category: Content
```

## Backward compatibility

Categorization is exposed through the optional `CategorizedSettingsInterface`. Existing custom `SettingsInterface` implementations remain valid without implementing categories and are grouped under `Other`.

The `category` configuration option remains optional. Fake settings and their distinct form fields are only defined in the dev configuration, so no demo settings are introduced in production.

## Cache operations and safety

- Field metadata is cached by settings alias, form class, and locale in the dedicated `monsieurbiz_settings.search_cache` pool.
- Run `monsieurbiz:settings:search-cache:clear` to clear only the settings search cache.
- Form introspection failures emit a warning with the settings alias, form class when available, and exception class, without exception messages or other sensitive details.

## Testing

- `vendor/bin/phpunit tests/Unit/DependencyInjection/ConfigurationTest.php tests/Unit/DependencyInjection/MonsieurBizSyliusSettingsExtensionTest.php tests/Unit/Search/SettingsSearchIndexBuilderTest.php tests/Unit/Command/ClearSettingsSearchCacheCommandTest.php tests/Unit/Twig/SettingsCardsTemplateTest.php` - passed (16 tests, 58 assertions).
- `make test.phpstan` - passed with no errors.
- `make test.phpcs` - passed; PHP-CS-Fixer found no files to fix.
- `node --check src/Resources/public/js/default.js` - passed.
- `make test.yaml` - passed (8 YAML files).
- `make test.twig` - passed (25 Twig files).
- `make test.container` - passed.
- `git diff --check` - passed.

## Demo

<img width="1728" height="905" alt="Settings search and categories" src="https://github.com/user-attachments/assets/a0fb760e-a0d6-4f58-9428-1bd619060443" />

### The small dot indicates that the search matches a field in the form.

<img width="1728" height="877" alt="Form field search match indicator" src="https://github.com/user-attachments/assets/ee00597a-a7b3-45ea-a4b7-a7e06de0570b" />